### PR TITLE
Clarification in doc-block for server(int port)

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/ClientBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/ClientBuilder.java
@@ -296,7 +296,7 @@ public interface ClientBuilder extends Cloneable {
     ClientBuilder messageDelay(int delay);
 
     /**
-     * Sets the server IP to which the client will connect.
+     * Sets the server port to which the client will connect.
      * <p>
      * By default, the port is 6667.
      *


### PR DESCRIPTION
World's most trivial PR!

IMO the methods might be better named `serverPort` and `serverHost`.