### PR TITLE
Make ecdsa-nist256p-challenge work correctly

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/auth/protocol/SaslECDSANIST256PChallenge.java
+++ b/src/main/java/org/kitteh/irc/client/library/auth/protocol/SaslECDSANIST256PChallenge.java
@@ -119,7 +119,7 @@ public class SaslECDSANIST256PChallenge extends AbstractSaslProtocol<PrivateKey>
     }
 
     public static String sign(PrivateKey privateKey, String base64Challenge) throws SignatureException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
-        Signature signature = Signature.getInstance("SHA256withECDSA");
+        Signature signature = Signature.getInstance("NONEwithECDSA");
         signature.initSign(privateKey);
         signature.update(Base64.getDecoder().decode(base64Challenge));
         return Base64.getEncoder().encodeToString(signature.sign());
@@ -134,11 +134,11 @@ public class SaslECDSANIST256PChallenge extends AbstractSaslProtocol<PrivateKey>
 
     // TODO UNIT TEST BELOW
     public static void signAndVerify(PrivateKey privateKey, String challenge, PublicKey publicKey) throws SignatureException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
-        Signature signature = Signature.getInstance("SHA256withECDSA");
+        Signature signature = Signature.getInstance("NONEwithECDSA");
         signature.initSign(privateKey);
         signature.update(Base64.getDecoder().decode(challenge));
         byte[] signed = signature.sign();
-        Signature ver = Signature.getInstance("SHA256withECDSA");
+        Signature ver = Signature.getInstance("NONEwithECDSA");
         ver.initVerify(publicKey);
         ver.update(Base64.getDecoder().decode(challenge));
         System.out.println("Verified: " + ver.verify(signed));

--- a/src/main/java/org/kitteh/irc/client/library/auth/protocol/SaslECDSANIST256PChallenge.java
+++ b/src/main/java/org/kitteh/irc/client/library/auth/protocol/SaslECDSANIST256PChallenge.java
@@ -27,7 +27,6 @@ import net.engio.mbassy.listener.Filter;
 import net.engio.mbassy.listener.Handler;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.event.client.ClientReceiveCommandEvent;
-import org.kitteh.irc.client.library.exception.KittehEventException;
 import org.kitteh.irc.client.library.util.CommandFilter;
 
 import javax.annotation.Nonnull;
@@ -90,7 +89,7 @@ public class SaslECDSANIST256PChallenge extends AbstractSaslProtocol<PrivateKey>
 
     @Override
     protected String getAuthLine() {
-        return this.getUsername()+'\0'+this.getUsername();
+        return this.getUsername() + "\0" + this.getUsername() + "\0";
     }
 
     @Nonnull


### PR DESCRIPTION
This PR:

* Cleans up code slightly (unused import, missing newline at end of file)
* Changes to include null byte at end of first authenticate line (as suggested in #atheme)
* Changes to sign challenge directly (thanks to amdj for explaining the SHA256 hash was wrong and to mbaxter for suggesting which signature algorithm to use instead(

Tested with latest git version of atheme (d3037892a863a9de2be1ef80609f3aba3d658896).