### PR TITLE
Update VERSION for Maven repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ public class Example {
 <dependency>
     <groupId>org.kitteh.irc</groupId>
     <artifactId>client-lib</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Perhaps a different mechanic should be written to keep the README updated, it sounds like this might be recipe for disaster when people don't know there's a more recent KICL version.