### PR TITLE
API for bans, abstracted to support quiets/exempt

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/element/Channel.java
+++ b/src/main/java/org/kitteh/irc/client/library/element/Channel.java
@@ -29,7 +29,9 @@ import org.kitteh.irc.client.library.command.KickCommand;
 import org.kitteh.irc.client.library.command.TopicCommand;
 import org.kitteh.irc.client.library.element.mode.ChannelMode;
 import org.kitteh.irc.client.library.element.mode.ChannelUserMode;
+import org.kitteh.irc.client.library.element.mode.ModeInfo;
 import org.kitteh.irc.client.library.element.mode.ModeStatusList;
+import org.kitteh.irc.client.library.event.channel.ChannelModeInfoListEvent;
 import org.kitteh.irc.client.library.event.channel.ChannelUsersUpdatedEvent;
 import org.kitteh.irc.client.library.util.Sanity;
 
@@ -82,6 +84,16 @@ public interface Channel extends MessageReceiver, Staleable {
     default Optional<Channel> getLatest() {
         return this.getClient().getChannel(this.getName());
     }
+
+    /**
+     * Gets the tracked mode info for the channel, if tracked.
+     *
+     * @param mode type A mode to acquire
+     * @return list of mode info if tracked, empty if not tracked
+     * @throws IllegalArgumentException for null or non-type-A mode
+     */
+    @Nonnull
+    Optional<List<ModeInfo>> getModeInfoList(@Nonnull ChannelMode mode);
 
     /**
      * Gets the channel's current known modes.
@@ -240,6 +252,18 @@ public interface Channel extends MessageReceiver, Staleable {
     default void part(@Nonnull String reason) {
         this.getClient().removeChannel(this.getName(), reason);
     }
+
+    /**
+     * Sets whether a particular type A mode should be tracked for this
+     * channel, and sends a request for the full list.
+     *
+     * @param mode mode to track
+     * @param track true to track, false to stop tracking
+     * @throws IllegalArgumentException for null or non-type-A mode
+     * @throws IllegalStateException if not in channel
+     * @see ChannelModeInfoListEvent
+     */
+    void setModeInfoTracking(@Nonnull ChannelMode mode, boolean track);
 
     /**
      * Attempts to set the topic of the channel.

--- a/src/main/java/org/kitteh/irc/client/library/element/mode/ModeInfo.java
+++ b/src/main/java/org/kitteh/irc/client/library/element/mode/ModeInfo.java
@@ -1,0 +1,94 @@
+/*
+ * * Copyright (C) 2013-2016 Matt Baxter http://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.element.mode;
+
+import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.command.ChannelModeCommand;
+import org.kitteh.irc.client.library.element.Channel;
+import org.kitteh.irc.client.library.util.Mask;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Represents a type A mode information entry.
+ */
+public interface ModeInfo {
+    /**
+     * Gets the name of the party listed as creating the entry. This may be a
+     * nickname, a service name, a server name, etc.
+     *
+     * @return name, if known, of who created this entry
+     */
+    @Nonnull
+    Optional<String> getCreator();
+
+    /**
+     * Gets the channel for which this entry exists.
+     *
+     * @return the channel
+     */
+    @Nonnull
+    Channel getChannel();
+
+    /**
+     * Gets the client that received this information.
+     *
+     * @return the client
+     */
+    @Nonnull
+    Client getClient();
+
+    /**
+     * Gets the mask.
+     *
+     * @return the mask
+     */
+    @Nonnull
+    Mask getMask();
+
+    /**
+     * Gets the mode for which this info exists.
+     *
+     * @return the mode
+     */
+    @Nonnull
+    ChannelMode getMode();
+
+    /**
+     * Gets the time at which this entry was created.
+     *
+     * @return creation time, if known
+     */
+    @Nonnull
+    Optional<Instant> getCreationTime();
+
+    /**
+     * Attempts to remove this item from the channel.
+     */
+    default void remove() {
+        new ChannelModeCommand(this.getClient(), this.getChannel().getName()).add(false, this.getMode(), this.getMask().asString()).execute();
+    }
+}

--- a/src/main/java/org/kitteh/irc/client/library/event/channel/ChannelModeInfoListEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/channel/ChannelModeInfoListEvent.java
@@ -1,0 +1,78 @@
+/*
+ * * Copyright (C) 2013-2016 Matt Baxter http://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.event.channel;
+
+import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.element.Channel;
+import org.kitteh.irc.client.library.element.ServerMessage;
+import org.kitteh.irc.client.library.element.mode.ChannelMode;
+import org.kitteh.irc.client.library.element.mode.ModeInfo;
+import org.kitteh.irc.client.library.event.abstractbase.ChannelEventBase;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A list of mode info is available!
+ */
+public class ChannelModeInfoListEvent extends ChannelEventBase {
+    private final ChannelMode mode;
+    private final List<ModeInfo> info;
+
+    /**
+     * Constructs the event.
+     *
+     * @param client client for which this is occurring
+     * @param originalMessages original messages
+     * @param channel channel with this info
+     * @param mode mode for which the info exists
+     * @param info list of info
+     */
+    public ChannelModeInfoListEvent(@Nonnull Client client, @Nonnull List<ServerMessage> originalMessages, @Nonnull Channel channel, @Nonnull ChannelMode mode, @Nonnull List<ModeInfo> info) {
+        super(client, originalMessages, channel);
+        this.mode = mode;
+        this.info = Collections.unmodifiableList(info);
+    }
+
+    /**
+     * Gets the mode info's mode.
+     *
+     * @return mode
+     */
+    @Nonnull
+    public ChannelMode getMode() {
+        return this.mode;
+    }
+
+    /**
+     * Gets the channel's mode info.
+     *
+     * @return info
+     */
+    @Nonnull
+    public List<ModeInfo> getModeInfo() {
+        return this.info;
+    }
+}

--- a/src/main/java/org/kitteh/irc/client/library/implementation/ModeData.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/ModeData.java
@@ -24,12 +24,17 @@
 package org.kitteh.irc.client.library.implementation;
 
 import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.element.Channel;
 import org.kitteh.irc.client.library.element.mode.ChannelMode;
 import org.kitteh.irc.client.library.element.mode.ChannelUserMode;
+import org.kitteh.irc.client.library.element.mode.ModeInfo;
 import org.kitteh.irc.client.library.element.mode.UserMode;
+import org.kitteh.irc.client.library.util.Mask;
 import org.kitteh.irc.client.library.util.ToStringer;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.util.Optional;
 
 final class ModeData {
     abstract static class IRCModeBase {
@@ -101,6 +106,66 @@ final class ModeData {
         @Override
         public String toString() {
             return new ToStringer(this).add("client", this.getClient()).add("char", this.getChar()).toString();
+        }
+    }
+
+    static class IRCModeInfo implements ModeInfo {
+        private final Client client;
+        private final Optional<Instant> creationTime;
+        private final Optional<String> creator;
+        private final Channel channel;
+        private final Mask mask;
+        private final ChannelMode mode;
+
+        IRCModeInfo(@Nonnull Client client, @Nonnull Channel channel, @Nonnull ChannelMode mode, @Nonnull String mask, @Nonnull Optional<String> creator, @Nonnull Optional<Instant> creationTime) {
+            this.client = client;
+            this.creator = creator;
+            this.channel = channel;
+            this.mask = Mask.fromString(mask);
+            this.creationTime = creationTime;
+            this.mode = mode;
+        }
+
+        @Nonnull
+        @Override
+        public Optional<String> getCreator() {
+            return this.creator;
+        }
+
+        @Nonnull
+        @Override
+        public Channel getChannel() {
+            return this.channel;
+        }
+
+        @Nonnull
+        @Override
+        public Client getClient() {
+            return this.client;
+        }
+
+        @Nonnull
+        @Override
+        public Mask getMask() {
+            return this.mask;
+        }
+
+        @Nonnull
+        @Override
+        public ChannelMode getMode() {
+            return this.mode;
+        }
+
+        @Nonnull
+        @Override
+        public Optional<Instant> getCreationTime() {
+            return this.creationTime;
+        }
+
+        @Nonnull
+        @Override
+        public String toString() {
+            return new ToStringer(this).add("client", this.client).add("channel", this.channel).add("mode", this.mode).add("mask", this.mask).add("creator", this.creator).add("creationTime", this.creationTime).toString();
         }
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/util/Mask.java
+++ b/src/main/java/org/kitteh/irc/client/library/util/Mask.java
@@ -1,0 +1,77 @@
+/*
+ * * Copyright (C) 2013-2016 Matt Baxter http://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.util;
+
+import org.kitteh.irc.client.library.element.User;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a mask that can match a {@link User}.
+ */
+public class Mask {
+    /**
+     * Creates a Mask from a given String.
+     *
+     * @param string string
+     * @return mask from string
+     */
+    @Nonnull
+    public static Mask fromString(@Nonnull String string) {
+        Sanity.nullCheck(string, "String cannot be null");
+        return new Mask(string);
+    }
+
+    private final String string;
+
+    private Mask(@Nonnull String string) {
+        this.string = string;
+    }
+
+    /**
+     * Gets the String representation of this mask.
+     *
+     * @return string
+     */
+    @Nonnull
+    public String asString() {
+        return this.string;
+    }
+
+    @Override
+    public int hashCode() {
+        return (2 * this.string.hashCode()) + 5;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof Mask) && ((Mask) o).string.equals(this.string);
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return new ToStringer(this).add("string", this.string).toString();
+    }
+}


### PR DESCRIPTION
Done:
* Create `Ban` element
* Create a list of `Ban`s when `MODE #channel +b` gets a reply

TODO:
* [x] Track bans for channels the client is in
* [x] Convenience method for removing a ban
* [x] Event for ban list being updated (e.g. shortly after channel join)
* [x] *Maybe* toggle tracking of bans per channel.