### PR TITLE
Implement ability to access library version in code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,17 @@
                 </includes>
                 <filtering>true</filtering>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <filtering>true</filtering>
+            </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources/</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/kitteh/irc/client/library/implementation/KICLProperties.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/KICLProperties.java
@@ -1,0 +1,62 @@
+/*
+ * * Copyright (C) 2013-2016 Matt Baxter http://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.implementation;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * A POJO representation of the bundled kicl.properties file. 
+ */
+public class KICLProperties {
+
+    public static final String DEFAULT_VERSION = "unknown";
+
+    private static Properties properties;
+
+    static {
+        try {
+            properties = new Properties(createDefaults());
+            properties.load(KICLProperties.class.getResourceAsStream("/kicl.properties"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Properties createDefaults() {
+        Properties props = new Properties();
+        props.put("version", DEFAULT_VERSION);
+        return props;
+    }
+
+    /**
+     * Returns the KittehIRCClientLib version during the compile-time. If the metadata file is not present,
+     * {@link #DEFAULT_VERSION} is returned instead.
+     *
+     * @return version as string
+     */
+    public static String getVersion() {
+        return properties.getProperty("version");
+    }
+}

--- a/src/main/resources/kicl.properties
+++ b/src/main/resources/kicl.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/test/java/org/kitteh/irc/client/library/implementation/KICLPropertiesTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/implementation/KICLPropertiesTest.java
@@ -1,0 +1,12 @@
+package org.kitteh.irc.client.library.implementation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KICLPropertiesTest {
+
+    @Test
+    public void testVersion() throws Exception {
+        Assert.assertNotEquals(KICLProperties.DEFAULT_VERSION, KICLProperties.getVersion());
+    }
+}

--- a/src/test/resources/kicl.properties
+++ b/src/test/resources/kicl.properties
@@ -1,0 +1,1 @@
+version=${project.version}


### PR DESCRIPTION
Hi Kittehs,

I've implemented the ability to access the maven version in compilation time during runtime. It's really magical how it works. I've created a file called `kicl.properties`. Unlike your average text file, this file is actually one better, it follows conventions that some people wrote some time ago. You write some codenames followed by = followed by some values and in the end you get like a dictionary of things that you can use. As I said, it is quite magical. Despite the fact that I come from the land of Harry Potter and was top of my class in the Hogwarts software wizardry, I spared my time for a bunch of you muggles. You might think I'm doing this out of the kindness of my heart, no. As a wizard, one of the few embarrassments that follow me is that I can't spawn these hacktoberfest shirts, especially since I don't know the design yet. Accept my Pull Demand so I can get the shirt!

Wingardium Leviosa
# hacktoberfest #magicalcode
