### PR TITLE
Documentation fixes

### DIFF
--- a/docs/advanced/ecdsa.md
+++ b/docs/advanced/ecdsa.md
@@ -51,6 +51,7 @@ openssl pkey -inform pem -outform der -in private_key.pem -out public_key.der -p
 ```sh
 openssl pkcs8 -topk8 -inform PEM -outform DER -in private_key.pem -out private_key.der -nocrypt
 ```
+
 Now, we base64 the two DER files so they can be used as arguments to the `getPublicKey`
 and `getPrivateKey` static methods on the `SaslECDSANIST256PChallenge` class:
 
@@ -110,7 +111,7 @@ package their public key
 
 The client sends `AUTHENTICATE ECDSA-NIST256P-CHALLENGE` to request that the authentication
 process be started. See the [SASL documentation](http://ircv3.net/specs/extensions/sasl-3.1.html)
- for more information on the SASL process.
+for more information on the SASL process.
 
 #### Step 2 - Wait for server acknowledgement
 
@@ -120,7 +121,7 @@ Once this message has been seen, the client can begin sending the user informati
 #### Step 3 - Send encapsulated username information
 
 The username to authenticate with, along with the identity to impersonate are concatenated
- and joined together by \0 (NUL byte, U+0000) characters. For example, logging in as user Example and impersonating Test:
+and joined together by \0 (NUL byte, U+0000) characters. For example, logging in as user Example and impersonating Test:
 
 `Example\0Test\0`
 
@@ -147,13 +148,13 @@ representation directly) and sign it, using the user's private key. The signatur
 This is a good approach for many usecases, especially when a lot of data is involved but it's
 important you **sign the provided challenge directly** for this process - Atheme does not
 support checking a cryptographic signature of the challenge. Java users should use `NoneWithECDSA`
- signature algorithm to achieve this.
+signature algorithm to achieve this.
 
 #### Step 5 - Send signature to server
 
 Now that the challenge has been signed, the signature should be encoded using base64 and sent back
- to the server, using the AUTHENTICATE command again. If everything went to plan, the authentication
-  should succeed.
+to the server, using the AUTHENTICATE command again. If everything went to plan, the authentication
+should succeed.
 
 ### Tools
 

--- a/docs/advanced/ssl_import.md
+++ b/docs/advanced/ssl_import.md
@@ -10,11 +10,15 @@ verification.
 
 1. Download the root certificates in DER form. For StartCom's roots, these can be obtained using wget:
 
-`wget https://www.startssl.com/certs/der/ca.crt https://www.startssl.com/certs/der/ca-g2.crt`
+```sh
+wget https://www.startssl.com/certs/der/ca.crt https://www.startssl.com/certs/der/ca-g2.crt
+```
 
 If the certificates you want to import aren't available in DER form, you can convert one in PEM form using:
 
-`openssl x509 -in certificate.crt -out certificate.der -outform DER`
+```sh
+openssl x509 -in certificate.crt -out certificate.der -outform DER
+```
 
 1. Locate the `cacerts` file. This is located in the `lib` of the JAVA_HOME directory. For example,
 `/usr/lib/jvm/java-8-oracle/jre/lib/cacerts` on a Ubuntu system.
@@ -23,10 +27,15 @@ If the certificates you want to import aren't available in DER form, you can con
 which is set by default to 'changeit'. If you've not changed it, you should be able to simply use this password. You can
 supply an alias for each certificate via the `-alias` argument.
 
-`sudo keytool -trustcacerts -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts -noprompt -importcert -alias StartCom1 -file ca.crt `
+```sh
+sudo keytool -trustcacerts -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts -noprompt -importcert -alias StartCom1 -file ca.crt 
+```
 
 You can list all certificates in your trust store and verify the certificates were correctly added by issuing
-`sudo keytool -trustcacerts -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts -list`
+
+```sh
+sudo keytool -trustcacerts -keystore /usr/lib/jvm/java-8-oracle/jre/lib/security/cacerts -list
+```
 
 At this point, the certificates should now be imported and connections made using the JRE's default `TrustManagerFactory`
 should work.

--- a/docs/advanced/webirc.md
+++ b/docs/advanced/webirc.md
@@ -1,9 +1,9 @@
 *Please note that some server software refers to the WebIRC protocol as cgiirc in configuration files.*
 
 KICL supports the WEBIRC command which is used for indirect connections such that the IRC server is made
- aware of the user's own IP address. For example, consider a webchat client. Without WebIRC support, all
- connections made through the web client would appear to originate from the webserver's IP address. With
- WebIRC support, the (trusted) webchat client sends the following information on connect:
+aware of the user's own IP address. For example, consider a webchat client. Without WebIRC support, all
+connections made through the web client would appear to originate from the webserver's IP address. With
+WebIRC support, the (trusted) webchat client sends the following information on connect:
 
 * A password that is kept secret between the IRC server and the client requesting the spoofing.
 * The name of the client doing the proxying and requesting the spoof (e.g. this is 'qwebirc' for Iris and
@@ -12,10 +12,10 @@ KICL supports the WEBIRC command which is used for indirect connections such tha
 * The user's IPv4/IPv6 address.
 
 KICL supports version 1 of the specification, documented [here](https://kiwiirc.com/docs/webirc). The code
- sample below shows how to configure KICL to send a WEBIRC command on connect. In the example, "MyBot" is
- the name of the client requesting the spoof.
+sample below shows how to configure KICL to send a WEBIRC command on connect. In the example, "MyBot" is
+the name of the client requesting the spoof.
 
-```
+```java
 InetAddress ip = ...; // User's IP address
 Client client = Client.builder().webirc("password", "MyBot", "host", ip).build();
 ```
@@ -24,7 +24,9 @@ Client client = Client.builder().webirc("password", "MyBot", "host", ip).build()
 
 * [Mibbit WebIRC page](https://wiki.mibbit.com/index.php/WebIRC) - covers the structure of the WEBIRC command,
  expectations for clients and servers supporting the protocol and more.
-* [Atheme Iris WEBIRC code](https://github.com/atheme/iris/blob/831483f6487312bf75a96dde3ce3fa63f46f5857/qwebirc/ircclient.py#L166) -
+* [qwebirc WEBIRC code](https://bitbucket.org/qwebirc/qwebirc/src/default/qwebirc/ircclient.py) - Python code for a
+  WEBIRC client.
+* [Atheme Iris WEBIRC code](https://github.com/atheme-legacy/iris/blob/master/qwebirc/ircclient.py) -
 Python code for a WEBIRC client.
-* [Charybdis WEBIRC code](https://github.com/atheme/charybdis/blob/master/extensions/m_webirc.c) - Server-side code
+* [Charybdis WEBIRC code](https://github.com/charybdis-ircd/charybdis/blob/release/4/extensions/m_webirc.c) - Server-side code
 that handles the WEBIRC command and sets the user's hostname and IP address appropriately.

--- a/docs/events.md
+++ b/docs/events.md
@@ -3,6 +3,7 @@
 KICL utilizes the [MBassador](https://github.com/bennidi/mbassador) event bus.
 
 Listening to an event is as simple as follows:
+
 ```java
 @Handler
 public void meow(ClientConnectedEvent event) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ client.sendMessage("#kitteh.org", "Hello World!");
 It can be useful to see input, output, and exceptions thrown while developing.
 
 Use the `ClientBuilder` methods `listenInput`, `listenOutput`, and `listenException` to catch these little surprises.
-Here is a simple example, printing all of the info to console.
+Here is a simple example, printing all of the info to the console:
 
 ```java
 SimpleDateFormat sdf = new SimpleDateFormat("mm:ss");
@@ -49,7 +49,7 @@ builder.listenOutput(line -> System.out.println(sdf.format(new Date()) + ' ' + "
 builder.listenException(Throwable::printStackTrace);
 ```
 
-## Using KICL in your maven project
+## Using KICL in your Maven project
 
 KICL is built and deployed using Maven. Releases are available on Maven Central. Adding it as a dependency is simple as adding the lines below to your pom.xml file:
 
@@ -64,7 +64,7 @@ KICL is built and deployed using Maven. Releases are available on Maven Central.
 
 ## Events
 
-KICL uses a simple event system driven by ```@Handler``` annotations.
+KICL uses a simple event system driven by `@Handler` annotations.
 A simple event listener example is shown below.
 For more information on events, see the [Events](events.md) documentation.
 
@@ -91,5 +91,5 @@ public class FriendlyBot {
 Consult the [JavaDocs](http://kittehorg.github.io/KittehIRCClientLib/) to answer most questions.
 
 Visit us in `#kitteh.org` on `irc.esper.net` for a chat (click
-[here](http://webchat.esper.net/?nick=kicl_...&channels=kitteh.org&prompt=1) to join), or check out the
+[here](https://webchat.esper.net/?nick=kicl_...&channels=%23kitteh.org&prompt=1) to join), or check out the
 [Issue Tracker](https://github.com/KittehOrg/KittehIRCClientLib/issues) if you have trouble.


### PR DESCRIPTION
This corrects numerous typos, inconsistencies, missing syntax highlighting, dead links, and other things.

It's worth to note that instead of referencing direct commit hashes in advanced/webirc.md, we now reference just the file. Atheme is no longer supported and I found the bitbucket UI clunky for referencing line numbers.  I also reference the charybdis release/4 branch because in the master branch they were still using .cc files which were changed, meaning it would turn into a dead link later unless you directly reference the file. Serving the newest version of the file tends to be better than an old version (especially for development)

View markdown files at https://github.com/Zarthus/KittehIRCClientLib/tree/documentation_fixes/docs