### PR TITLE
ClientBuilder: Allow message delays of 0 ms.

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/implementation/ClientBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/ClientBuilder.java
@@ -162,7 +162,7 @@ final class ClientBuilder implements Client.Builder, Cloneable {
     @Nonnull
     @Override
     public ClientBuilder messageDelay(int delay) {
-        Sanity.truthiness(delay >= 0, "Delay must be a positive integer");
+        Sanity.truthiness(delay >= 0, "Delay cannot be negative");
 
         if (delay != 0) {
             this.config.set(Config.MESSAGE_DELAY, delay);

--- a/src/main/java/org/kitteh/irc/client/library/implementation/ClientBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/ClientBuilder.java
@@ -163,7 +163,14 @@ final class ClientBuilder implements Client.Builder, Cloneable {
     @Override
     public ClientBuilder messageDelay(int delay) {
         Sanity.truthiness(delay >= 0, "Delay must be a positive integer");
-        this.config.set(Config.MESSAGE_DELAY, delay);
+
+        if (delay != 0) {
+            this.config.set(Config.MESSAGE_DELAY, delay);
+        } else {
+            // Due to limitations with ScheduledExecutorService, we need a delay of at least 1 ms.
+            this.config.set(Config.MESSAGE_DELAY, 1);
+        }
+
         return this;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/implementation/ClientBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/ClientBuilder.java
@@ -162,7 +162,7 @@ final class ClientBuilder implements Client.Builder, Cloneable {
     @Nonnull
     @Override
     public ClientBuilder messageDelay(int delay) {
-        Sanity.truthiness(delay > 0, "Delay must be at least 1");
+        Sanity.truthiness(delay >= 0, "Delay must be a positive integer");
         this.config.set(Config.MESSAGE_DELAY, delay);
         return this;
     }


### PR DESCRIPTION
This seemed like an arbitrary restriction to me.

While I haven't tested if this makes KICL go bonkers (and I'm hoping travis catches it if it does), this should have no negative repercussions and in theory would be an arbitrary restriction.

Primarily useful for when you want to make dynamic configurations that implement KICL, the chances someone will set this to "0" over "1" is quite high, and it makes sense to allow 0 for that.
