### PR TITLE
Implement access to maven manifest version.

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/util/KiclVersion.java
+++ b/src/main/java/org/kitteh/irc/client/library/util/KiclVersion.java
@@ -1,0 +1,31 @@
+package org.kitteh.irc.client.library.util;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Represents a class that serves no other purpose than to provide the current KittehIRCClientLib version.
+ */
+public final class KiclVersion {
+
+    /**
+     * KittehIRCClientLib maven version at time of compilation.
+     */
+    public static final String VERSION;
+
+    static {
+        String version = "unknown";
+        // try to load from maven properties first
+        try {
+            Properties p = new Properties();
+            InputStream is = KiclVersion.class.getResourceAsStream("/META-INF/maven/org.kitteh.irc/client-lib/pom.properties");
+            if (is != null) {
+                p.load(is);
+                version = p.getProperty("version", version);
+            }
+        } catch (Exception ignored) {
+        }
+        VERSION = version;
+    }
+
+}


### PR DESCRIPTION
This Pull Request implements an access point in the codebase for the KittehIRCClientLib version at the time of compilation. This PR fully depends on the Maven build system as it uses the META-INF generated by maven. If for some reason users decide to not have KICL's manifest files in their fatjar, then KICL will fallback to version string `"unknown"`.

I do not prefer this implementation over #144 as it does fully depend on Maven and leaves the user with too much unnecessary control. However, it is a much simpler version. It should be noted you can't write unit tests for this feature (at least I couldn't find a way), due to the nature of the implementation.
# Hacktoberfest #OneMoreToGo.
