### PR TITLE
Increase maximum message line length

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
@@ -77,7 +77,7 @@ import java.util.concurrent.TimeUnit;
 
 final class NettyManager {
     static final class ClientConnection {
-        private static final int MAX_LINE_LENGTH = 2048;
+        private static final int MAX_LINE_LENGTH = 4096;
 
         private final InternalClient client;
         private final Channel channel;


### PR DESCRIPTION
Twitch sometimes sends messages bigger than 2048 bytes (up to 2240 bytes over multiple days of checking ALL Twitch chat messages).

A limit of 4096 seems pretty safe.