### PR TITLE
Better connection handling events

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/Client.java
+++ b/src/main/java/org/kitteh/irc/client/library/Client.java
@@ -39,7 +39,7 @@ import org.kitteh.irc.client.library.element.User;
 import org.kitteh.irc.client.library.element.mode.ModeStatusList;
 import org.kitteh.irc.client.library.element.mode.UserMode;
 import org.kitteh.irc.client.library.event.channel.RequestedChannelJoinCompleteEvent;
-import org.kitteh.irc.client.library.event.client.ClientConnectedEvent;
+import org.kitteh.irc.client.library.event.client.ClientNegotiationCompleteEvent;
 import org.kitteh.irc.client.library.event.helper.UnexpectedChannelLeaveEvent;
 import org.kitteh.irc.client.library.event.user.PrivateCTCPQueryEvent;
 import org.kitteh.irc.client.library.feature.AuthManager;
@@ -720,7 +720,7 @@ public interface Client {
      * connected. As long as the client remains connected the information
      * returned by this object will update according to information received
      * from the server. A new one can be acquired from {@link
-     * ClientConnectedEvent}
+     * ClientNegotiationCompleteEvent}
      *
      * @return the server information object
      */

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionClosedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionClosedEvent.java
@@ -42,11 +42,11 @@ public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
      *
      * @param client client for which this is occurring
      * @param reconnecting true if the client plans to reconnect
-     * @param exception exception, if there was one, closing it
+     * @param cause cause, if there was one, closing it
      * @param lastMessage last message received
      */
-    public ClientConnectionClosedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception, @Nullable String lastMessage) {
-        super(client, reconnecting, exception);
+    public ClientConnectionClosedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Throwable cause, @Nullable String lastMessage) {
+        super(client, reconnecting, cause);
         this.lastMessage = lastMessage;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionClosedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionClosedEvent.java
@@ -34,7 +34,8 @@ import java.util.Optional;
  * The {@link Client} has had a working connection cease.
  */
 public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
-    private final Optional<String> lastMessage;
+    @Nullable
+    private final String lastMessage;
 
     /**
      * Constructs the event.
@@ -46,7 +47,7 @@ public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
      */
     public ClientConnectionClosedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception, @Nullable String lastMessage) {
         super(client, reconnecting, exception);
-        this.lastMessage = Optional.ofNullable(lastMessage);
+        this.lastMessage = lastMessage;
     }
 
     /**
@@ -58,7 +59,7 @@ public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
      */
     @Nonnull
     public Optional<String> getLastMessage() {
-        return this.lastMessage;
+        return Optional.ofNullable(this.lastMessage);
     }
 
     @Override

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
@@ -24,6 +24,7 @@
 package org.kitteh.irc.client.library.event.client;
 
 import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.event.abstractbase.ClientEventBase;
 import org.kitteh.irc.client.library.util.ToStringer;
 
 import javax.annotation.Nonnull;
@@ -31,10 +32,12 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
- * The {@link Client} has had a working connection cease.
+ * The {@link Client} has had a connection end.
  */
-public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
-    private final Optional<String> lastMessage;
+public abstract class ClientConnectionEndedEvent extends ClientEventBase {
+    private final Optional<Exception> exception;
+    private boolean reconnecting;
+    private int reconnectionDelayMillis = 5000;
 
     /**
      * Constructs the event.
@@ -42,28 +45,61 @@ public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
      * @param client client for which this is occurring
      * @param reconnecting true if the client plans to reconnect
      * @param exception exception, if there was one, closing it
-     * @param lastMessage last message received
      */
-    public ClientConnectionClosedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception, @Nullable String lastMessage) {
-        super(client, reconnecting, exception);
-        this.lastMessage = Optional.ofNullable(lastMessage);
+    protected ClientConnectionEndedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception) {
+        super(client);
+        this.reconnecting = reconnecting;
+        this.exception = Optional.ofNullable(exception);
     }
 
     /**
-     * Gets the last message sent prior to disconnect. Useful if killed from
-     * the server. This message may not have been processed yet by other
-     * events.
-     *
-     * @return last message, or empty, sent by the server
+     * TODO javadoc
+     * @return
      */
     @Nonnull
-    public Optional<String> getLastMessage() {
-        return this.lastMessage;
+    public Optional<Exception> getException() {
+        return this.exception;
+    }
+
+    /**
+     * TODO javadoc
+     *
+     * @return
+     */
+    public int getReconnectionDelay() {
+        return this.reconnectionDelayMillis;
+    }
+
+    /**
+     * Gets if the client plans to reconnect to the server.
+     *
+     * @return true if the client will attempt to reconnect
+     */
+    public boolean isReconnecting() {
+        return this.reconnecting;
+    }
+
+    /**
+     * //TODO shutdown condition, javadoc
+     *
+     * @param reconnecting
+     */
+    public void setReconnecting(boolean reconnecting) {
+        this.reconnecting = reconnecting;
+    }
+
+    /**
+     * TODO javadoc
+     *
+     * @param millis
+     */
+    public void setReconnectionDelay(int millis) {
+        this.reconnectionDelayMillis = millis;
     }
 
     @Override
     @Nonnull
     protected ToStringer toStringer() {
-        return super.toStringer().add("lastMessage", this.lastMessage);
+        return super.toStringer().add("isReconnecting", this.reconnecting).add("reconnectionDelay", this.reconnectionDelayMillis);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
@@ -36,9 +36,15 @@ import java.util.Optional;
  * The {@link Client} has had a connection end.
  */
 public abstract class ClientConnectionEndedEvent extends ClientEventBase implements ConnectionEvent {
-    private final Optional<Exception> exception;
+    /**
+     * Default reconnection delay, in milliseconds.
+     */
+    public static final int DEFAULT_RECONNECTION_DELAY_MILLIS = 5000;
+
+    @Nullable
+    private final Exception exception;
     private boolean reconnecting;
-    private int reconnectionDelayMillis = 5000;
+    private int reconnectionDelayMillis = DEFAULT_RECONNECTION_DELAY_MILLIS;
 
     /**
      * Constructs the event.
@@ -50,7 +56,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     protected ClientConnectionEndedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception) {
         super(client);
         this.reconnecting = reconnecting;
-        this.exception = Optional.ofNullable(exception);
+        this.exception = exception;
     }
 
     /**
@@ -59,7 +65,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      */
     @Nonnull
     public Optional<Exception> getException() {
-        return this.exception;
+        return Optional.ofNullable(this.exception);
     }
 
     /**

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
@@ -26,6 +26,7 @@ package org.kitteh.irc.client.library.event.client;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.event.abstractbase.ClientEventBase;
 import org.kitteh.irc.client.library.event.helper.ConnectionEvent;
+import org.kitteh.irc.client.library.util.Sanity;
 import org.kitteh.irc.client.library.util.ToStringer;
 
 import javax.annotation.Nonnull;
@@ -60,8 +61,9 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     }
 
     /**
-     * TODO javadoc
-     * @return
+     * Gets the exception that caused this disconnect, if there was one.
+     *
+     * @return exception or empty if no exception
      */
     @Nonnull
     public Optional<Exception> getException() {
@@ -69,9 +71,11 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     }
 
     /**
-     * TODO javadoc
+     * Gets the delay until reconnection.
      *
-     * @return
+     * @return reconnection delay, in milliseconds
+     * @see #isReconnecting()
+     * @see #setReconnecting(boolean)
      */
     public int getReconnectionDelay() {
         return this.reconnectionDelayMillis;
@@ -87,20 +91,25 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     }
 
     /**
-     * //TODO shutdown condition, javadoc
+     * Sets if the client will attempt to connect again.
      *
-     * @param reconnecting
+     * @param reconnecting true to reconnect, false to not reconnect
      */
     public void setReconnecting(boolean reconnecting) {
+        // TODO client shutdown condition
         this.reconnecting = reconnecting;
     }
 
     /**
-     * TODO javadoc
+     * Sets the delay until a reconnection attempt, in milliseconds.
      *
-     * @param millis
+     * @param millis reconnection delay
+     * @throws IllegalArgumentException if negative
+     * @see #isReconnecting()
+     * @see #setReconnecting(boolean)
      */
     public void setReconnectionDelay(int millis) {
+        Sanity.truthiness(millis > -1, "Delay cannot be negative");
         this.reconnectionDelayMillis = millis;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
@@ -44,7 +44,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
 
     private final boolean canReconnect;
     @Nullable
-    private final Exception exception;
+    private final Throwable cause;
     private int reconnectionDelayMillis = DEFAULT_RECONNECTION_DELAY_MILLIS;
     private boolean attemptReconnect;
 
@@ -53,13 +53,13 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      *
      * @param client client for which this is occurring
      * @param canReconnect true if the client plans to reconnect
-     * @param exception exception, if there was one, closing it
+     * @param cause cause, if there was one, closing it
      */
-    protected ClientConnectionEndedEvent(@Nonnull Client client, boolean canReconnect, @Nullable Exception exception) {
+    protected ClientConnectionEndedEvent(@Nonnull Client client, boolean canReconnect, @Nullable Throwable cause) {
         super(client);
         this.canReconnect = canReconnect;
         this.attemptReconnect = canReconnect;
-        this.exception = exception;
+        this.cause = cause;
     }
 
     /**
@@ -68,8 +68,8 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      * @return exception or empty if no exception
      */
     @Nonnull
-    public Optional<Exception> getException() {
-        return Optional.ofNullable(this.exception);
+    public Optional<Throwable> getCause() {
+        return Optional.ofNullable(this.cause);
     }
 
     /**
@@ -136,6 +136,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
         return super.toStringer()
                 .add("canAttemptReconnect", this.canReconnect)
                 .add("willAttemptReconnect", this.attemptReconnect)
-                .add("reconnectionDelay", this.reconnectionDelayMillis);
+                .add("reconnectionDelay", this.reconnectionDelayMillis)
+                .add("cause", this.cause);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
@@ -25,6 +25,7 @@ package org.kitteh.irc.client.library.event.client;
 
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.event.abstractbase.ClientEventBase;
+import org.kitteh.irc.client.library.event.helper.ConnectionEvent;
 import org.kitteh.irc.client.library.util.ToStringer;
 
 import javax.annotation.Nonnull;
@@ -34,7 +35,7 @@ import java.util.Optional;
 /**
  * The {@link Client} has had a connection end.
  */
-public abstract class ClientConnectionEndedEvent extends ClientEventBase {
+public abstract class ClientConnectionEndedEvent extends ClientEventBase implements ConnectionEvent {
     private final Optional<Exception> exception;
     private boolean reconnecting;
     private int reconnectionDelayMillis = 5000;

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEndedEvent.java
@@ -46,7 +46,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     @Nullable
     private final Exception exception;
     private int reconnectionDelayMillis = DEFAULT_RECONNECTION_DELAY_MILLIS;
-    private boolean tryReconnection;
+    private boolean attemptReconnect;
 
     /**
      * Constructs the event.
@@ -58,7 +58,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     protected ClientConnectionEndedEvent(@Nonnull Client client, boolean canReconnect, @Nullable Exception exception) {
         super(client);
         this.canReconnect = canReconnect;
-        this.tryReconnection = canReconnect;
+        this.attemptReconnect = canReconnect;
         this.exception = exception;
     }
 
@@ -76,9 +76,9 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      * Gets the delay until reconnection.
      *
      * @return reconnection delay, in milliseconds
-     * @see #isReconnectable()
-     * @see #isTryingReconnection()
-     * @see #setTryReconnection(boolean)
+     * @see #canAttemptReconnect()
+     * @see #willAttemptReconnect()
+     * @see #setAttemptReconnect(boolean)
      */
     public int getReconnectionDelay() {
         return this.reconnectionDelayMillis;
@@ -90,7 +90,7 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      *
      * @return true if the client can reconnect
      */
-    public boolean isReconnectable() {
+    public boolean canAttemptReconnect() {
         return this.canReconnect;
     }
 
@@ -99,21 +99,21 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      *
      * @return true if the client will attempt to reconnect
      */
-    public boolean isTryingReconnection() {
-        return this.canReconnect && this.tryReconnection;
+    public boolean willAttemptReconnect() {
+        return this.canReconnect && this.attemptReconnect;
     }
 
     /**
      * Sets if the client will attempt to connect again. Note that this will
-     * only happen if {@link #isReconnectable()} is true as the client cannot
+     * only happen if {@link #canAttemptReconnect()} is true as the client cannot
      * try to reconnect if it has been shutdown. Setting to true will still
-     * result in a false {@link #isTryingReconnection()} if it is not able
+     * result in a false {@link #willAttemptReconnect()} if it is not able
      * to reconnect.
      *
      * @param reconnecting true to reconnect, false to not reconnect
      */
-    public void setTryReconnection(boolean reconnecting) {
-        this.tryReconnection = reconnecting;
+    public void setAttemptReconnect(boolean reconnecting) {
+        this.attemptReconnect = reconnecting;
     }
 
     /**
@@ -121,9 +121,9 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
      *
      * @param millis reconnection delay
      * @throws IllegalArgumentException if negative
-     * @see #isReconnectable()
-     * @see #isTryingReconnection()
-     * @see #setTryReconnection(boolean)
+     * @see #canAttemptReconnect()
+     * @see #willAttemptReconnect()
+     * @see #setAttemptReconnect(boolean)
      */
     public void setReconnectionDelay(int millis) {
         Sanity.truthiness(millis > -1, "Delay cannot be negative");
@@ -134,8 +134,8 @@ public abstract class ClientConnectionEndedEvent extends ClientEventBase impleme
     @Nonnull
     protected ToStringer toStringer() {
         return super.toStringer()
-                .add("canReconnect", this.canReconnect)
-                .add("isTryingReconnection", this.tryReconnection)
+                .add("canAttemptReconnect", this.canReconnect)
+                .add("willAttemptReconnect", this.attemptReconnect)
                 .add("reconnectionDelay", this.reconnectionDelayMillis);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEstablishedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionEstablishedEvent.java
@@ -24,46 +24,21 @@
 package org.kitteh.irc.client.library.event.client;
 
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.util.ToStringer;
+import org.kitteh.irc.client.library.event.abstractbase.ClientEventBase;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Optional;
 
 /**
- * The {@link Client} has had a working connection cease.
+ * The {@link Client} has connected to the server and is about to begin IRC
+ * negotiation.
  */
-public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
-    private final Optional<String> lastMessage;
-
+public class ClientConnectionEstablishedEvent extends ClientEventBase {
     /**
      * Constructs the event.
      *
      * @param client client for which this is occurring
-     * @param reconnecting true if the client plans to reconnect
-     * @param exception exception, if there was one, closing it
-     * @param lastMessage last message received
      */
-    public ClientConnectionClosedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception, @Nullable String lastMessage) {
-        super(client, reconnecting, exception);
-        this.lastMessage = Optional.ofNullable(lastMessage);
-    }
-
-    /**
-     * Gets the last message sent prior to disconnect. Useful if killed from
-     * the server. This message may not have been processed yet by other
-     * events.
-     *
-     * @return last message, or empty, sent by the server
-     */
-    @Nonnull
-    public Optional<String> getLastMessage() {
-        return this.lastMessage;
-    }
-
-    @Override
-    @Nonnull
-    protected ToStringer toStringer() {
-        return super.toStringer().add("lastMessage", this.lastMessage);
+    public ClientConnectionEstablishedEvent(@Nonnull Client client) {
+        super(client);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionFailedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionFailedEvent.java
@@ -24,46 +24,22 @@
 package org.kitteh.irc.client.library.event.client;
 
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.util.ToStringer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 /**
- * The {@link Client} has had a working connection cease.
+ * The {@link Client} has had a connection failure.
  */
-public class ClientConnectionClosedEvent extends ClientConnectionEndedEvent {
-    private final Optional<String> lastMessage;
-
+public class ClientConnectionFailedEvent extends ClientConnectionEndedEvent {
     /**
      * Constructs the event.
      *
      * @param client client for which this is occurring
      * @param reconnecting true if the client plans to reconnect
      * @param exception exception, if there was one, closing it
-     * @param lastMessage last message received
      */
-    public ClientConnectionClosedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception, @Nullable String lastMessage) {
+    public ClientConnectionFailedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception) {
         super(client, reconnecting, exception);
-        this.lastMessage = Optional.ofNullable(lastMessage);
-    }
-
-    /**
-     * Gets the last message sent prior to disconnect. Useful if killed from
-     * the server. This message may not have been processed yet by other
-     * events.
-     *
-     * @return last message, or empty, sent by the server
-     */
-    @Nonnull
-    public Optional<String> getLastMessage() {
-        return this.lastMessage;
-    }
-
-    @Override
-    @Nonnull
-    protected ToStringer toStringer() {
-        return super.toStringer().add("lastMessage", this.lastMessage);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionFailedEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientConnectionFailedEvent.java
@@ -37,9 +37,9 @@ public class ClientConnectionFailedEvent extends ClientConnectionEndedEvent {
      *
      * @param client client for which this is occurring
      * @param reconnecting true if the client plans to reconnect
-     * @param exception exception, if there was one, closing it
+     * @param cause cause, if there was one, closing it
      */
-    public ClientConnectionFailedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Exception exception) {
-        super(client, reconnecting, exception);
+    public ClientConnectionFailedEvent(@Nonnull Client client, boolean reconnecting, @Nullable Throwable cause) {
+        super(client, reconnecting, cause);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientNegotiationCompleteEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientNegotiationCompleteEvent.java
@@ -33,11 +33,11 @@ import org.kitteh.irc.client.library.util.ToStringer;
 import javax.annotation.Nonnull;
 
 /**
- * The {@link Client} has successfully connected to the server. At this time
- * the client will begin to send queued messages which were not essential to
- * establishing the connection.
+ * The {@link Client} has successfully completed negotiation with the server.
+ * At this time the client will begin to send queued messages which were not
+ * essential to negotiating the connection.
  */
-public class ClientConnectedEvent extends ClientEventBase {
+public class ClientNegotiationCompleteEvent extends ClientEventBase {
     private final Actor server;
     private final ServerInfo serverInfo;
 
@@ -48,7 +48,7 @@ public class ClientConnectedEvent extends ClientEventBase {
      * @param server the server to which the client is connected
      * @param serverInfo information about the server
      */
-    public ClientConnectedEvent(@Nonnull Client client, @Nonnull Actor server, @Nonnull ServerInfo serverInfo) {
+    public ClientNegotiationCompleteEvent(@Nonnull Client client, @Nonnull Actor server, @Nonnull ServerInfo serverInfo) {
         super(client);
         this.server = Sanity.nullCheck(server, "Server cannot be null");
         this.serverInfo = Sanity.nullCheck(serverInfo, "ServerInfo cannot be null");

--- a/src/main/java/org/kitteh/irc/client/library/event/helper/ConnectionEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/helper/ConnectionEvent.java
@@ -21,25 +21,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.kitteh.irc.client.library.event.client;
-
-import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.event.abstractbase.ClientEventBase;
-import org.kitteh.irc.client.library.event.helper.ConnectionEvent;
-
-import javax.annotation.Nonnull;
+package org.kitteh.irc.client.library.event.helper;
 
 /**
- * The {@link Client} has connected to the server and is about to begin IRC
- * negotiation.
+ * An event involving a Client's connection.
  */
-public class ClientConnectionEstablishedEvent extends ClientEventBase implements ConnectionEvent {
-    /**
-     * Constructs the event.
-     *
-     * @param client client for which this is occurring
-     */
-    public ClientConnectionEstablishedEvent(@Nonnull Client client) {
-        super(client);
-    }
+public interface ConnectionEvent extends ClientEvent {
 }

--- a/src/main/java/org/kitteh/irc/client/library/feature/defaultmanager/DefaultEventManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/defaultmanager/DefaultEventManager.java
@@ -30,7 +30,7 @@ import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 import net.engio.mbassy.bus.error.PublicationError;
 import net.engio.mbassy.listener.Handler;
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.event.client.ClientConnectionClosedEvent;
+import org.kitteh.irc.client.library.event.client.ClientConnectionEndedEvent;
 import org.kitteh.irc.client.library.event.helper.ClientEvent;
 import org.kitteh.irc.client.library.exception.KittehEventException;
 import org.kitteh.irc.client.library.exception.KittehNagException;
@@ -168,7 +168,7 @@ public class DefaultEventManager implements EventManager {
      * @param event event of doom
      */
     @Handler(priority = Integer.MIN_VALUE)
-    public void onShutdown(ClientConnectionClosedEvent event) {
+    public void onShutdown(ClientConnectionEndedEvent event) {
         if (!event.isReconnecting()) {
             this.bus.shutdown();
         }

--- a/src/main/java/org/kitteh/irc/client/library/feature/defaultmanager/DefaultEventManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/defaultmanager/DefaultEventManager.java
@@ -169,7 +169,7 @@ public class DefaultEventManager implements EventManager {
      */
     @Handler(priority = Integer.MIN_VALUE)
     public void onShutdown(ClientConnectionEndedEvent event) {
-        if (!event.isReconnectable()) {
+        if (!event.canAttemptReconnect()) {
             this.bus.shutdown();
         }
     }

--- a/src/main/java/org/kitteh/irc/client/library/feature/defaultmanager/DefaultEventManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/defaultmanager/DefaultEventManager.java
@@ -169,7 +169,7 @@ public class DefaultEventManager implements EventManager {
      */
     @Handler(priority = Integer.MIN_VALUE)
     public void onShutdown(ClientConnectionEndedEvent event) {
-        if (!event.isReconnecting()) {
+        if (!event.isReconnectable()) {
             this.bus.shutdown();
         }
     }

--- a/src/main/java/org/kitteh/irc/client/library/implementation/Config.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/Config.java
@@ -257,8 +257,7 @@ final class Config {
                 try {
                     Entry<?> entry = (Entry<?>) field.get(null);
                     Object setEntry = this.get(entry);
-                    @Nullable
-                    final String info;
+                    @Nullable final String info;
                     if (setEntry == null) {
                         info = null;
                     } else if (entry.noToString) {

--- a/src/main/java/org/kitteh/irc/client/library/implementation/EventListener.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/EventListener.java
@@ -68,7 +68,7 @@ import org.kitteh.irc.client.library.event.channel.RequestedChannelJoinCompleteE
 import org.kitteh.irc.client.library.event.channel.UnexpectedChannelLeaveViaKickEvent;
 import org.kitteh.irc.client.library.event.channel.UnexpectedChannelLeaveViaPartEvent;
 import org.kitteh.irc.client.library.event.client.ClientAwayStatusChangeEvent;
-import org.kitteh.irc.client.library.event.client.ClientConnectedEvent;
+import org.kitteh.irc.client.library.event.client.ClientNegotiationCompleteEvent;
 import org.kitteh.irc.client.library.event.client.ClientReceiveCommandEvent;
 import org.kitteh.irc.client.library.event.client.ClientReceiveMOTDEvent;
 import org.kitteh.irc.client.library.event.client.ClientReceiveNumericEvent;
@@ -162,7 +162,7 @@ class EventListener {
         if (!isTwitch) {
             this.client.sendRawLineImmediately("WHOIS " + this.client.getNick());
         }
-        this.fire(new ClientConnectedEvent(this.client, event.getActor(), this.client.getServerInfo()));
+        this.fire(new ClientNegotiationCompleteEvent(this.client, event.getActor(), this.client.getServerInfo()));
         this.client.startSending();
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
@@ -110,7 +110,7 @@ final class NettyManager {
                     ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, this.reconnect, exception);
                     this.client.getEventManager().callEvent(event);
                     this.client.getExceptionListener().queue(new KittehConnectionException(future.cause(), false));
-                    if (event.isTryingReconnection()) {
+                    if (event.willAttemptReconnect()) {
                         this.scheduleReconnect(event.getReconnectionDelay());
                     }
                 }
@@ -224,7 +224,7 @@ final class NettyManager {
                 @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
                 ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, exception, this.lastMessage);
                 ClientConnection.this.client.getEventManager().callEvent(event);
-                if (event.isTryingReconnection()) {
+                if (event.willAttemptReconnect()) {
                     this.scheduleReconnect(event.getReconnectionDelay());
                 }
             });

--- a/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
@@ -106,8 +106,7 @@ final class NettyManager {
                     this.client.getEventManager().callEvent(new ClientConnectionEstablishedEvent(this.client));
                     this.client.beginMessageSendingImmediate(this.channel::writeAndFlush);
                 } else {
-                    @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
-                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, this.reconnect, exception);
+                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, this.reconnect, future.cause());
                     this.client.getEventManager().callEvent(event);
                     this.client.getExceptionListener().queue(new KittehConnectionException(future.cause(), false));
                     if (event.willAttemptReconnect()) {
@@ -221,8 +220,7 @@ final class NettyManager {
                 if (this.ping != null) {
                     this.ping.cancel(true);
                 }
-                @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
-                ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, exception, this.lastMessage);
+                ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, future.cause(), this.lastMessage);
                 ClientConnection.this.client.getEventManager().callEvent(event);
                 if (event.willAttemptReconnect()) {
                     this.scheduleReconnect(event.getReconnectionDelay());

--- a/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
@@ -106,7 +106,8 @@ final class NettyManager {
                     this.client.getEventManager().callEvent(new ClientConnectionEstablishedEvent(this.client));
                     this.client.beginMessageSendingImmediate(this.channel::writeAndFlush);
                 } else {
-                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, true, (future.cause() instanceof Exception) ? (Exception) future.cause() : null);
+                    @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
+                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, true, exception);
                     this.client.getEventManager().callEvent(event);
                     this.client.getExceptionListener().queue(new KittehConnectionException(future.cause(), false));
                     if (event.isReconnecting()) {
@@ -220,7 +221,8 @@ final class NettyManager {
                 if (this.ping != null) {
                     this.ping.cancel(true);
                 }
-                ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, (future.cause() instanceof Exception) ? (Exception) future.cause() : null, this.lastMessage);
+                @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
+                ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, exception, this.lastMessage);
                 ClientConnection.this.client.getEventManager().callEvent(event);
                 if (event.isReconnecting()) {
                     this.scheduleReconnect(event.getReconnectionDelay());

--- a/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
@@ -51,6 +51,8 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.ScheduledFuture;
 import org.kitteh.irc.client.library.event.client.ClientConnectionClosedEvent;
+import org.kitteh.irc.client.library.event.client.ClientConnectionEstablishedEvent;
+import org.kitteh.irc.client.library.event.client.ClientConnectionFailedEvent;
 import org.kitteh.irc.client.library.exception.KittehConnectionException;
 import org.kitteh.irc.client.library.exception.KittehNagException;
 import org.kitteh.irc.client.library.exception.KittehSTSException;
@@ -90,6 +92,8 @@ final class NettyManager {
 
         private ScheduledFuture<?> ping;
 
+        private volatile String lastMessage;
+
         private ClientConnection(@Nonnull final InternalClient client, @Nonnull ChannelFuture channelFuture) {
             this.client = client;
             this.channel = channelFuture.channel();
@@ -99,10 +103,15 @@ final class NettyManager {
                 ClientConnection.this.channelFuture = null;
                 if (future.isSuccess()) {
                     this.buildOurFutureTogether();
+                    this.client.getEventManager().callEvent(new ClientConnectionEstablishedEvent(this.client));
                     this.client.beginMessageSendingImmediate(this.channel::writeAndFlush);
                 } else {
+                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, true, (future.cause() instanceof Exception) ? (Exception) future.cause() : null);
+                    this.client.getEventManager().callEvent(event);
                     this.client.getExceptionListener().queue(new KittehConnectionException(future.cause(), false));
-                    this.scheduleReconnect();
+                    if (event.isReconnecting()) {
+                        this.scheduleReconnect(event.getReconnectionDelay());
+                    }
                 }
             });
         }
@@ -149,6 +158,7 @@ final class NettyManager {
                     }
                     ClientConnection.this.client.getInputListener().queue(msg);
                     ClientConnection.this.client.processLine(msg);
+                    ClientConnection.this.lastMessage = msg;
                 }
             });
 
@@ -206,19 +216,20 @@ final class NettyManager {
             });
 
             // Clean up on disconnect
-            this.channel.closeFuture().addListener(futureListener -> {
-                if (ClientConnection.this.reconnect) {
-                    this.scheduleReconnect();
-                }
+            this.channel.closeFuture().addListener(future -> {
                 if (this.ping != null) {
                     this.ping.cancel(true);
                 }
-                ClientConnection.this.client.getEventManager().callEvent(new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect));
+                ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, (future.cause() instanceof Exception) ? (Exception) future.cause() : null, this.lastMessage);
+                ClientConnection.this.client.getEventManager().callEvent(event);
+                if (event.isReconnecting()) {
+                    this.scheduleReconnect(event.getReconnectionDelay());
+                }
             });
         }
 
-        private void scheduleReconnect() {
-            ClientConnection.this.channel.eventLoop().schedule(ClientConnection.this.client::connect, 5, TimeUnit.SECONDS);
+        private void scheduleReconnect(int delay) {
+            ClientConnection.this.channel.eventLoop().schedule(ClientConnection.this.client::connect, delay, TimeUnit.MILLISECONDS);
         }
 
         private void handleException(Exception thrown) {

--- a/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/NettyManager.java
@@ -107,10 +107,10 @@ final class NettyManager {
                     this.client.beginMessageSendingImmediate(this.channel::writeAndFlush);
                 } else {
                     @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
-                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, true, exception);
+                    ClientConnectionFailedEvent event = new ClientConnectionFailedEvent(this.client, this.reconnect, exception);
                     this.client.getEventManager().callEvent(event);
                     this.client.getExceptionListener().queue(new KittehConnectionException(future.cause(), false));
-                    if (event.isReconnecting()) {
+                    if (event.isTryingReconnection()) {
                         this.scheduleReconnect(event.getReconnectionDelay());
                     }
                 }
@@ -224,7 +224,7 @@ final class NettyManager {
                 @Nullable final Exception exception = (future.cause() instanceof Exception) ? (Exception) future.cause() : null;
                 ClientConnectionClosedEvent event = new ClientConnectionClosedEvent(ClientConnection.this.client, ClientConnection.this.reconnect, exception, this.lastMessage);
                 ClientConnection.this.client.getEventManager().callEvent(event);
-                if (event.isReconnecting()) {
+                if (event.isTryingReconnection()) {
                     this.scheduleReconnect(event.getReconnectionDelay());
                 }
             });

--- a/src/main/java/org/kitteh/irc/client/library/implementation/STSHandler.java
+++ b/src/main/java/org/kitteh/irc/client/library/implementation/STSHandler.java
@@ -28,7 +28,7 @@ import org.kitteh.irc.client.library.element.CapabilityState;
 import org.kitteh.irc.client.library.element.ServerMessage;
 import org.kitteh.irc.client.library.event.capabilities.CapabilitiesNewSupportedEvent;
 import org.kitteh.irc.client.library.event.capabilities.CapabilitiesSupportedListEvent;
-import org.kitteh.irc.client.library.event.client.ClientConnectionClosedEvent;
+import org.kitteh.irc.client.library.event.client.ClientConnectionEndedEvent;
 import org.kitteh.irc.client.library.exception.KittehServerMessageException;
 import org.kitteh.irc.client.library.feature.sts.STSClientState;
 import org.kitteh.irc.client.library.feature.sts.STSMachine;
@@ -116,7 +116,7 @@ class STSHandler {
      * @param event the event instance
      */
     @Handler
-    public void onDisconnect(ClientConnectionClosedEvent event) {
+    public void onDisconnect(ClientConnectionEndedEvent event) {
         // The spec says we have to update the expiry of the policy if it still exists
         // at disconnection time...
         // Do this by removing and re-adding.

--- a/src/test/java/org/kitteh/irc/client/library/implementation/EventListenerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/implementation/EventListenerTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kitteh.irc.client.library.element.ISupportParameter;
 import org.kitteh.irc.client.library.element.defaults.DefaultServerMessage;
-import org.kitteh.irc.client.library.event.client.ClientConnectedEvent;
+import org.kitteh.irc.client.library.event.client.ClientNegotiationCompleteEvent;
 import org.kitteh.irc.client.library.event.client.ClientReceiveCommandEvent;
 import org.kitteh.irc.client.library.event.client.ClientReceiveNumericEvent;
 import org.kitteh.irc.client.library.event.user.WallopsEvent;
@@ -155,7 +155,7 @@ public class EventListenerTest {
         Mockito.verify(this.serverInfo, Mockito.times(1)).setAddress("irc.network");
         Mockito.verify(this.serverInfo, Mockito.times(1)).setVersion("kittydis-1.3.3.7-dev");
         Mockito.verify(this.client, Mockito.times(1)).startSending();
-        Mockito.verify(this.eventManager, Mockito.times(1)).callEvent(Mockito.argThat(this.match(ClientConnectedEvent.class, event -> "irc.network".equals(event.getServer().getName()) && event.getServerInfo().equals(this.serverInfo))));
+        Mockito.verify(this.eventManager, Mockito.times(1)).callEvent(Mockito.argThat(this.match(ClientNegotiationCompleteEvent.class, event -> "irc.network".equals(event.getServer().getName()) && event.getServerInfo().equals(this.serverInfo))));
     }
 
     /**
@@ -168,7 +168,7 @@ public class EventListenerTest {
         Mockito.verify(this.serverInfo, Mockito.times(1)).setAddress("irc.network");
         Mockito.verify(this.serverInfo, Mockito.times(0)).setVersion(Mockito.anyString());
         Mockito.verify(this.client, Mockito.times(1)).startSending();
-        Mockito.verify(this.eventManager, Mockito.times(1)).callEvent(Mockito.argThat(this.match(ClientConnectedEvent.class)));
+        Mockito.verify(this.eventManager, Mockito.times(1)).callEvent(Mockito.argThat(this.match(ClientNegotiationCompleteEvent.class)));
         Mockito.verify(this.exceptionListener, Mockito.times(1)).queue(Mockito.argThat(this.exception(KittehServerMessageException.class, "Server version and user modes missing")));
     }
 
@@ -183,7 +183,7 @@ public class EventListenerTest {
         Mockito.verify(this.serverInfo, Mockito.times(0)).setAddress(Mockito.anyString());
         Mockito.verify(this.serverInfo, Mockito.times(0)).setVersion(Mockito.anyString());
         Mockito.verify(this.client, Mockito.times(1)).startSending();
-        Mockito.verify(this.eventManager, Mockito.times(1)).callEvent(Mockito.argThat(this.match(ClientConnectedEvent.class)));
+        Mockito.verify(this.eventManager, Mockito.times(1)).callEvent(Mockito.argThat(this.match(ClientNegotiationCompleteEvent.class)));
         Mockito.verify(this.exceptionListener, Mockito.times(1)).queue(Mockito.argThat(this.exception(KittehServerMessageException.class, "Server address, version, and user modes missing")));
     }
 


### PR DESCRIPTION
Proposed modification to connection handling.

* Renamed the event at 004 to more accurate `ClientNegotiationCompleteEvent`
* New event `ClientConnectionEstablishedEvent` for start of connection
* New event `ClientConnectionEndedEvent` with children:
  * `ClientConnectionClosedEvent` for working connection that went dead.
  * `ClientConnectionFailedEvent` for connection attempt that failed.
  * Can customize if automatic reconnect after, or not.
  * Can customize reconnection delay.
