### PR TITLE
Do not untrack channel on other user's part

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/defaults/feature/DefaultActorTracker.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/feature/DefaultActorTracker.java
@@ -688,7 +688,7 @@ public class DefaultActorTracker implements ActorTracker {
 
     @Override
     public void trackUserPart(@Nonnull String channel, @Nonnull String nick) {
-        IrcChannel ch = this.trackedChannels.remove(channel);
+        IrcChannel ch = this.trackedChannels.get(channel);
         if (ch != null) {
             ch.trackUserPart(nick);
         }


### PR DESCRIPTION
Currently, when a different user (as in, not the user this client is connected as) parts a channel, that channel will be untracked, just as if you left the channel. Thus subsequent messages / parts will cause issues as the client thinks it just left the channel. This doesn't seem to be the correct behavior, as we would only want to invalidate the user that parted the channel instead of leaving it.