### PR TITLE
Add twitch whisper event

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/feature/twitch/event/WhisperEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/twitch/event/WhisperEvent.java
@@ -1,0 +1,32 @@
+package org.kitteh.irc.client.library.feature.twitch.event;
+
+import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.element.ServerMessage;
+import org.kitteh.irc.client.library.element.User;
+import org.kitteh.irc.client.library.event.user.PrivateMessageEvent;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Fires when a whisper is received via twitch.
+ */
+public class WhisperEvent extends PrivateMessageEvent implements TwitchSingleMessageEvent {
+    /**
+     * Creates the event.
+     *
+     * @param client client for which this is occurring
+     * @param originalMessages original messages
+     * @param sender who sent it
+     * @param target who received it
+     * @param message message sent
+     */
+    public WhisperEvent(@Nonnull Client client, @Nonnull List<ServerMessage> originalMessages, @Nonnull User sender, @Nonnull String target, @Nonnull String message) {
+        super(client, originalMessages, sender, target, message);
+    }
+
+    @Override
+    public void sendReply(@Nonnull String message) {
+        this.getClient().sendMessage("#jtv", "/w " + this.getActor().getNick() + " " + message);
+    }
+}


### PR DESCRIPTION
To extend the already existing support, this adds functionality for receiving whispers via twitch. This is handled in similar manner to the other twitch events. However, I opted not to alter any other part to make sending whispers easier (as explained in the commit, they're a little different) and instead only adapt the `sendReply` to work correctly.

I'm not sure how much twitch is wanted in here and this is a feature that could also just be done by the user instead, so no hard feelings from me if this is out of scope.