### PR TITLE
Add support for SOCKS proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>${dependency.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.0</version>

--- a/src/main/java/org/kitteh/irc/client/library/Client.java
+++ b/src/main/java/org/kitteh/irc/client/library/Client.java
@@ -84,6 +84,12 @@ import java.util.function.Function;
  * An individual IRC connection, see {@link #builder()} to create one.
  */
 public interface Client {
+
+    enum ProxyType {
+        SOCKS_4,
+        SOCKS_5
+    }
+
     /**
      * Builds {@link Client}s. Create a builder with {@link Client#builder()}.
      * <p>
@@ -305,6 +311,15 @@ public interface Client {
          */
         @Nonnull
         Builder secure(boolean secure);
+
+        @Nonnull
+        Builder proxyHost(String host);
+
+        @Nonnull
+        Builder proxyPort(int port);
+
+        @Nonnull
+        Builder proxyType(ProxyType type);
 
         /**
          * Sets the key for SSL connection.
@@ -631,6 +646,30 @@ public interface Client {
         @Nonnull
         InetSocketAddress getServerAddress();
 
+        /**
+         * Gets if the client is configured to use a proxy.
+         *
+         * @return {@code true} if configured for proxy
+         */
+        @Nonnull
+        boolean isProxyEnabled();
+
+        /**
+         * Gets if the client is configured to use a proxy.
+         *
+         * @return {@code true} if configured for proxy
+         */
+        @Nonnull
+        ProxyType getProxyType();
+
+        /**
+         * Gets the proxy address
+         *
+         * @return proxy address
+         */
+        @Nonnull
+        InetSocketAddress getProxyAddress();
+
         @Override
         @Nonnull
         ServerInfo.WithManagement getServerInfo();
@@ -708,6 +747,7 @@ public interface Client {
          */
         void initialize(@Nonnull String name, @Nonnull InetSocketAddress serverAddress, @Nullable String serverPassword,
                         @Nullable InetSocketAddress bindAddress,
+                        @Nullable InetSocketAddress proxyAddress, @Nullable ProxyType proxyType,
                         @Nonnull String nick, @Nonnull String userString, @Nonnull String realName, @Nonnull ActorTracker actorTracker,
                         @Nonnull AuthManager authManager, @Nonnull CapabilityManager.WithManagement capabilityManager,
                         @Nonnull EventManager eventManager, @Nonnull MessageTagManager messageTagManager,

--- a/src/main/java/org/kitteh/irc/client/library/Client.java
+++ b/src/main/java/org/kitteh/irc/client/library/Client.java
@@ -85,6 +85,9 @@ import java.util.function.Function;
  */
 public interface Client {
 
+    /**
+     * Type of proxy to use.
+     */
     enum ProxyType {
         SOCKS_4,
         SOCKS_5
@@ -312,12 +315,31 @@ public interface Client {
         @Nonnull
         Builder secure(boolean secure);
 
+        /**
+         * Sets the proxy host which the client will use when connecting to the server host.
+         *
+         * @param host proxy host
+         * @return this builder
+         * @throws IllegalArgumentException for null host
+         */
         @Nonnull
         Builder proxyHost(String host);
 
+        /**
+         * Sets the proxy port to which the client will connect.
+         *
+         * @param port proxy port
+         * @return this builder
+         */
         @Nonnull
         Builder proxyPort(int port);
 
+        /**
+         * Sets the type of proxy to use when the client connects to the server host.
+         *
+         * @param type one of {@link ProxyType}
+         * @return this builder
+         */
         @Nonnull
         Builder proxyType(ProxyType type);
 
@@ -652,15 +674,7 @@ public interface Client {
          * @return {@code true} if configured for proxy
          */
         @Nonnull
-        boolean isProxyEnabled();
-
-        /**
-         * Gets if the client is configured to use a proxy.
-         *
-         * @return {@code true} if configured for proxy
-         */
-        @Nonnull
-        ProxyType getProxyType();
+        Optional<ProxyType> getProxyType();
 
         /**
          * Gets the proxy address
@@ -668,7 +682,7 @@ public interface Client {
          * @return proxy address
          */
         @Nonnull
-        InetSocketAddress getProxyAddress();
+        Optional<InetSocketAddress> getProxyAddress();
 
         @Override
         @Nonnull

--- a/src/main/java/org/kitteh/irc/client/library/defaults/DefaultBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/DefaultBuilder.java
@@ -227,7 +227,7 @@ public class DefaultBuilder implements Client.Builder {
     @Nonnull
     @Override
     public Client.Builder proxyPort(int port) {
-        this.proxyPort = isValidPort(port);
+        this.proxyPort = this.isValidPort(port);
         return this;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/defaults/DefaultBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/DefaultBuilder.java
@@ -111,6 +111,12 @@ public class DefaultBuilder implements Client.Builder {
     @Nullable
     private String webircUser = null;
 
+    @Nullable
+    private String proxyHost;
+    private int proxyPort;
+    @Nullable
+    private Client.ProxyType proxyType;
+
     @Nonnull
     @Override
     public Client.Builder actorTracker(@Nonnull Function<Client.WithManagement, ? extends ActorTracker> supplier) {
@@ -208,6 +214,27 @@ public class DefaultBuilder implements Client.Builder {
     @Override
     public DefaultBuilder secure(boolean secure) {
         this.secure = secure;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Client.Builder proxyHost(String host) {
+        this.proxyHost = host;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Client.Builder proxyPort(int port) {
+        this.proxyPort = port;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Client.Builder proxyType(Client.ProxyType type) {
+        this.proxyType = type;
         return this;
     }
 
@@ -343,7 +370,9 @@ public class DefaultBuilder implements Client.Builder {
 
         Client.WithManagement client = new DefaultClient();
         client.initialize(this.name, this.getInetSocketAddress(this.serverHost, this.serverPort), this.serverPassword,
-                this.getInetSocketAddress(this.bindHost, this.bindPort), this.nick, this.userString, this.realName,
+                this.getInetSocketAddress(this.bindHost, this.bindPort),
+                this.getInetSocketAddress(this.proxyHost, this.proxyPort), this.proxyType,
+                this.nick, this.userString, this.realName,
                 this.actorTracker.apply(client),
                 this.authManager.apply(client), this.capabilityManager.apply(client), this.eventManager.apply(client),
                 this.messageTagManager.apply(client), this.iSupportManager.apply(client), this.defaultMessageMap, this.messageSendingQueue,

--- a/src/main/java/org/kitteh/irc/client/library/defaults/DefaultBuilder.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/DefaultBuilder.java
@@ -227,7 +227,7 @@ public class DefaultBuilder implements Client.Builder {
     @Nonnull
     @Override
     public Client.Builder proxyPort(int port) {
-        this.proxyPort = port;
+        this.proxyPort = isValidPort(port);
         return this;
     }
 
@@ -368,10 +368,14 @@ public class DefaultBuilder implements Client.Builder {
             Sanity.truthiness(!AcceptingTrustManagerFactory.isInsecure(this.secureTrustManagerFactory), "Cannot use STS with an insecure trust manager.");
         }
 
+        InetSocketAddress proxyAddress = null;
+        if (proxyHost != null && proxyPort > 0) {
+            proxyAddress = this.getInetSocketAddress(this.proxyHost, this.proxyPort);
+        }
         Client.WithManagement client = new DefaultClient();
         client.initialize(this.name, this.getInetSocketAddress(this.serverHost, this.serverPort), this.serverPassword,
                 this.getInetSocketAddress(this.bindHost, this.bindPort),
-                this.getInetSocketAddress(this.proxyHost, this.proxyPort), this.proxyType,
+                proxyAddress, this.proxyType,
                 this.nick, this.userString, this.realName,
                 this.actorTracker.apply(client),
                 this.authManager.apply(client), this.capabilityManager.apply(client), this.eventManager.apply(client),

--- a/src/main/java/org/kitteh/irc/client/library/defaults/DefaultClient.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/DefaultClient.java
@@ -213,6 +213,8 @@ public class DefaultClient implements Client.WithManagement {
     private String name;
     private InetSocketAddress bindAddress;
     private InetSocketAddress serverAddress;
+    private InetSocketAddress proxyAddress;
+    private ProxyType proxyType;
     private String serverPassword;
     private String userString;
     private String realName;
@@ -240,6 +242,7 @@ public class DefaultClient implements Client.WithManagement {
     @Override
     public void initialize(@Nonnull String name, @Nonnull InetSocketAddress serverAddress, @Nullable String serverPassword,
                            @Nullable InetSocketAddress bindAddress,
+                           @Nullable InetSocketAddress proxyAddress, @Nullable ProxyType proxyType,
                            @Nonnull String nick, @Nonnull String userString, @Nonnull String realName, @Nonnull ActorTracker actorTracker,
                            @Nonnull AuthManager authManager, @Nonnull CapabilityManager.WithManagement capabilityManager,
                            @Nonnull EventManager eventManager, @Nonnull MessageTagManager messageTagManager,
@@ -253,6 +256,8 @@ public class DefaultClient implements Client.WithManagement {
                            @Nullable InetAddress webircIP, @Nullable String webircPassword, @Nullable String webircUser) {
         this.name = name;
         this.serverAddress = serverAddress;
+        this.proxyAddress = proxyAddress;
+        this.proxyType = proxyType;
         this.serverPassword = serverPassword;
         this.bindAddress = bindAddress;
         this.currentNick = this.requestedNick = this.goalNick = nick;
@@ -566,6 +571,24 @@ public class DefaultClient implements Client.WithManagement {
     @Override
     public InetSocketAddress getServerAddress() {
         return this.serverAddress;
+    }
+
+    @Nonnull
+    @Override
+    public boolean isProxyEnabled() {
+        return this.proxyAddress != null;
+    }
+
+    @Nonnull
+    @Override
+    public ProxyType getProxyType() {
+        return this.proxyType;
+    }
+
+    @Nonnull
+    @Override
+    public InetSocketAddress getProxyAddress() {
+        return this.proxyAddress;
     }
 
     @Override

--- a/src/main/java/org/kitteh/irc/client/library/defaults/DefaultClient.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/DefaultClient.java
@@ -213,8 +213,8 @@ public class DefaultClient implements Client.WithManagement {
     private String name;
     private InetSocketAddress bindAddress;
     private InetSocketAddress serverAddress;
-    private InetSocketAddress proxyAddress;
-    private ProxyType proxyType;
+    private Optional<InetSocketAddress> proxyAddress;
+    private Optional<ProxyType> proxyType;
     private String serverPassword;
     private String userString;
     private String realName;
@@ -256,8 +256,8 @@ public class DefaultClient implements Client.WithManagement {
                            @Nullable InetAddress webircIP, @Nullable String webircPassword, @Nullable String webircUser) {
         this.name = name;
         this.serverAddress = serverAddress;
-        this.proxyAddress = proxyAddress;
-        this.proxyType = proxyType;
+        this.proxyAddress = Optional.ofNullable(proxyAddress);
+        this.proxyType = Optional.ofNullable(proxyType);
         this.serverPassword = serverPassword;
         this.bindAddress = bindAddress;
         this.currentNick = this.requestedNick = this.goalNick = nick;
@@ -575,19 +575,13 @@ public class DefaultClient implements Client.WithManagement {
 
     @Nonnull
     @Override
-    public boolean isProxyEnabled() {
-        return this.proxyAddress != null;
-    }
-
-    @Nonnull
-    @Override
-    public ProxyType getProxyType() {
+    public Optional<ProxyType> getProxyType() {
         return this.proxyType;
     }
 
     @Nonnull
     @Override
-    public InetSocketAddress getProxyAddress() {
+    public Optional<InetSocketAddress> getProxyAddress() {
         return this.proxyAddress;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/defaults/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/NettyManager.java
@@ -359,7 +359,7 @@ public class NettyManager {
                 public void initChannel(SocketChannel channel) {
                     if (client.getProxyType().isPresent() && client.getProxyAddress().isPresent()) {
                         ChannelPipeline pipe = channel.pipeline();
-                        switch(client.getProxyType().get()) {
+                        switch (client.getProxyType().get()) {
                             case SOCKS_5:
                                 pipe.addLast(new Socks5ProxyHandler(client.getProxyAddress().get()));
                                 break;

--- a/src/main/java/org/kitteh/irc/client/library/defaults/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/NettyManager.java
@@ -33,6 +33,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -42,6 +43,8 @@ import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.proxy.Socks4ProxyHandler;
+import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -337,7 +340,6 @@ public class NettyManager {
      * @return connection
      */
     public static synchronized ClientConnection connect(@Nonnull Client.WithManagement client) {
-
         // STS Override
         if (client.getStsMachine().isPresent() && !client.isSecureConnection()) {
             String hostname = client.getServerAddress().getHostName();
@@ -355,7 +357,20 @@ public class NettyManager {
             bootstrap.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
                 public void initChannel(SocketChannel channel) {
-                    // NOOP
+                    if(client.isProxyEnabled()) {
+                        ChannelPipeline pipe = channel.pipeline();
+                        switch(client.getProxyType()) {
+                            case SOCKS_5:
+                                pipe.addLast(new Socks5ProxyHandler(client.getProxyAddress()));
+                                break;
+                            case SOCKS_4:
+                                pipe.addLast(new Socks4ProxyHandler(client.getProxyAddress()));
+                                break;
+                            default:
+                                // unknown proxy, should not happen
+                                break;
+                        }
+                    }
                 }
             });
             bootstrap.option(ChannelOption.TCP_NODELAY, true);

--- a/src/main/java/org/kitteh/irc/client/library/defaults/NettyManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/NettyManager.java
@@ -357,18 +357,17 @@ public class NettyManager {
             bootstrap.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
                 public void initChannel(SocketChannel channel) {
-                    if(client.isProxyEnabled()) {
+                    if (client.getProxyType().isPresent() && client.getProxyAddress().isPresent()) {
                         ChannelPipeline pipe = channel.pipeline();
-                        switch(client.getProxyType()) {
+                        switch(client.getProxyType().get()) {
                             case SOCKS_5:
-                                pipe.addLast(new Socks5ProxyHandler(client.getProxyAddress()));
+                                pipe.addLast(new Socks5ProxyHandler(client.getProxyAddress().get()));
                                 break;
                             case SOCKS_4:
-                                pipe.addLast(new Socks4ProxyHandler(client.getProxyAddress()));
+                                pipe.addLast(new Socks4ProxyHandler(client.getProxyAddress().get()));
                                 break;
                             default:
-                                // unknown proxy, should not happen
-                                break;
+                                throw new IllegalArgumentException("Unsupported proxy type: " + client.getProxyType());
                         }
                     }
                 }

--- a/src/test/java/org/kitteh/irc/client/library/FakeClient.java
+++ b/src/test/java/org/kitteh/irc/client/library/FakeClient.java
@@ -75,7 +75,7 @@ public class FakeClient implements Client.WithManagement {
     }
 
     @Override
-    public void initialize(@Nonnull String name, @Nonnull InetSocketAddress serverAddress, @Nullable String serverPassword, @Nullable InetSocketAddress bindAddress, @Nonnull String nick, @Nonnull String userString, @Nonnull String realName, @Nonnull ActorTracker actorTracker, @Nonnull AuthManager authManager, @Nonnull CapabilityManager.WithManagement capabilityManager, @Nonnull EventManager eventManager, @Nonnull MessageTagManager messageTagManager, @Nonnull ISupportManager iSupportManager, @Nullable DefaultMessageMap defaultMessageMap, @Nonnull Function<WithManagement, ? extends MessageSendingQueue> messageSendingQueue, @Nonnull Function<WithManagement, ? extends ServerInfo.WithManagement> serverInfo, @Nullable Consumer<Exception> exceptionListener, @Nullable Consumer<String> inputListener, @Nullable Consumer<String> outputListener, boolean secure, @Nullable Path secureKeyCertChain, @Nullable Path secureKey, @Nullable String secureKeyPassword, @Nullable TrustManagerFactory trustManagerFactory, @Nullable StsStorageManager stsStorageManager, @Nullable String webircHost, @Nullable InetAddress webircIP, @Nullable String webircPassword, @Nullable String webircUser) {
+    public void initialize(@Nonnull String name, @Nonnull InetSocketAddress serverAddress, @Nullable String serverPassword, @Nullable InetSocketAddress bindAddress, @Nullable InetSocketAddress proxyAddress, @Nullable ProxyType proxyType, @Nonnull String nick, @Nonnull String userString, @Nonnull String realName, @Nonnull ActorTracker actorTracker, @Nonnull AuthManager authManager, @Nonnull CapabilityManager.WithManagement capabilityManager, @Nonnull EventManager eventManager, @Nonnull MessageTagManager messageTagManager, @Nonnull ISupportManager iSupportManager, @Nullable DefaultMessageMap defaultMessageMap, @Nonnull Function<WithManagement, ? extends MessageSendingQueue> messageSendingQueue, @Nonnull Function<WithManagement, ? extends ServerInfo.WithManagement> serverInfo, @Nullable Consumer<Exception> exceptionListener, @Nullable Consumer<String> inputListener, @Nullable Consumer<String> outputListener, boolean secure, @Nullable Path secureKeyCertChain, @Nullable Path secureKey, @Nullable String secureKeyPassword, @Nullable TrustManagerFactory trustManagerFactory, @Nullable StsStorageManager stsStorageManager, @Nullable String webircHost, @Nullable InetAddress webircIP, @Nullable String webircPassword, @Nullable String webircUser) {
 
     }
 
@@ -224,6 +224,25 @@ public class FakeClient implements Client.WithManagement {
     @Nonnull
     @Override
     public InetSocketAddress getServerAddress() {
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public boolean isProxyEnabled() {
+        // no proxy for fake clients
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public ProxyType getProxyType() {
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public InetSocketAddress getProxyAddress() {
         return null;
     }
 

--- a/src/test/java/org/kitteh/irc/client/library/FakeClient.java
+++ b/src/test/java/org/kitteh/irc/client/library/FakeClient.java
@@ -229,20 +229,13 @@ public class FakeClient implements Client.WithManagement {
 
     @Nonnull
     @Override
-    public boolean isProxyEnabled() {
-        // no proxy for fake clients
-        return false;
-    }
-
-    @Nonnull
-    @Override
-    public ProxyType getProxyType() {
+    public Optional<ProxyType> getProxyType() {
         return null;
     }
 
     @Nonnull
     @Override
-    public InetSocketAddress getProxyAddress() {
+    public Optional<InetSocketAddress> getProxyAddress() {
         return null;
     }
 


### PR DESCRIPTION
I want to use KittehIRCClientLib for a little project, but I need to be able to connect via a SOCKS proxy. I extended the `Client` and `DefaultBuilder` to support setting a SOCKS4/5 proxy.

````java
Client client = Client.builder()
                .nick("Kitteh")
                .serverHost("server.localdomain")
                .serverPort(6667)
                .secure(false)
                .proxyHost("localhost")
                .proxyPort(1234)
                .proxyType(Client.ProxyType.SOCKS_5)
                .buildAndConnect();
````

I did not add any tests yet and modified the `FakeClient` so it doesn't support any proxies. I tried to match the code style I found in the modified classes.

If there is anything I can do to improve this PR please let me know. 😄 