### PR TITLE
It's always DNS: Part one of resolver work (Breaking API for 5.0.0)

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/Client.java
+++ b/src/main/java/org/kitteh/irc/client/library/Client.java
@@ -69,6 +69,7 @@ import org.kitteh.irc.client.library.feature.sending.SingleDelaySender;
 import org.kitteh.irc.client.library.feature.sts.StsMachine;
 import org.kitteh.irc.client.library.feature.sts.StsStorageManager;
 import org.kitteh.irc.client.library.util.Cutter;
+import org.kitteh.irc.client.library.util.HostWithPort;
 import org.kitteh.irc.client.library.util.Listener;
 import org.kitteh.irc.client.library.util.Pair;
 import org.kitteh.irc.client.library.util.Sanity;
@@ -149,6 +150,17 @@ public interface Client extends ClientLinked {
          */
         interface Server {
             /**
+             * Sets the server host and port to which the client will connect.
+             * <p>
+             * By default, the host is localhost and port is 6697.
+             *
+             * @param hostWithPort IRC server host and port
+             * @return this builder
+             * @throws IllegalArgumentException for null parameter
+             */
+            @NonNull Server address(@NonNull HostWithPort hostWithPort);
+
+            /**
              * Sets the server host to which the client will connect.
              * <p>
              * By default, the host is localhost.
@@ -162,7 +174,7 @@ public interface Client extends ClientLinked {
             /**
              * Sets the server port to which the client will connect.
              * <p>
-             * By default, the port is 6667.
+             * By default, the port is 6697.
              *
              * @param port IRC server port
              * @return this builder
@@ -732,7 +744,7 @@ public interface Client extends ClientLinked {
          *
          * @return proxy address
          */
-        @NonNull Optional<InetSocketAddress> getProxyAddress();
+        @NonNull Optional<HostWithPort> getProxyAddress();
 
         /**
          * Gets the nickname the client has last requested.
@@ -774,7 +786,7 @@ public interface Client extends ClientLinked {
          *
          * @return server address
          */
-        @NonNull InetSocketAddress getServerAddress();
+        @NonNull HostWithPort getServerAddress();
 
         @Override
         ServerInfo.@NonNull WithManagement getServerInfo();
@@ -815,13 +827,13 @@ public interface Client extends ClientLinked {
          *
          * @param address server address
          */
-        void setServerAddress(@NonNull InetSocketAddress address);
+        void setServerAddress(@NonNull HostWithPort address);
 
         /**
          * Initialize with pre-connection information.
          *
          * @param name name
-         * @param serverAddress serverAddress
+         * @param serverHostWithPort serverHostWithPort
          * @param serverPassword serverPassword
          * @param bindAddress bindAddress
          * @param proxyAddress proxyAddress
@@ -853,9 +865,9 @@ public interface Client extends ClientLinked {
          * @param webircPassword webircPassword
          * @param webircUser webircUser
          */
-        void initialize(@NonNull String name, @NonNull InetSocketAddress serverAddress, @Nullable String serverPassword,
+        void initialize(@NonNull String name, @NonNull HostWithPort serverHostWithPort, @Nullable String serverPassword,
                         @Nullable InetSocketAddress bindAddress,
-                        @Nullable InetSocketAddress proxyAddress, @Nullable ProxyType proxyType,
+                        @Nullable HostWithPort proxyAddress, @Nullable ProxyType proxyType,
                         @NonNull String nick, @NonNull String userString, @NonNull String realName, @NonNull ActorTracker actorTracker,
                         @NonNull AuthManager authManager, CapabilityManager.@NonNull WithManagement capabilityManager,
                         @NonNull EventManager eventManager, @NonNull List<EventListenerSupplier> listenerSuppliers,

--- a/src/main/java/org/kitteh/irc/client/library/defaults/DefaultClient.java
+++ b/src/main/java/org/kitteh/irc/client/library/defaults/DefaultClient.java
@@ -68,6 +68,7 @@ import org.kitteh.irc.client.library.feature.sts.StsStorageManager;
 import org.kitteh.irc.client.library.util.CISet;
 import org.kitteh.irc.client.library.util.CtcpUtil;
 import org.kitteh.irc.client.library.util.Cutter;
+import org.kitteh.irc.client.library.util.HostWithPort;
 import org.kitteh.irc.client.library.util.Listener;
 import org.kitteh.irc.client.library.util.Pair;
 import org.kitteh.irc.client.library.util.QueueProcessingThread;
@@ -205,8 +206,8 @@ public class DefaultClient implements Client.WithManagement {
 
     private String name;
     private InetSocketAddress bindAddress;
-    private InetSocketAddress serverAddress;
-    private InetSocketAddress proxyAddress;
+    private HostWithPort serverAddress;
+    private HostWithPort proxyAddress;
     private ProxyType proxyType;
     private String serverPassword;
     private String userString;
@@ -233,9 +234,9 @@ public class DefaultClient implements Client.WithManagement {
     }
 
     @Override
-    public void initialize(@NonNull String name, @NonNull InetSocketAddress serverAddress, @Nullable String serverPassword,
+    public void initialize(@NonNull String name, @NonNull HostWithPort serverAddress, @Nullable String serverPassword,
                            @Nullable InetSocketAddress bindAddress,
-                           @Nullable InetSocketAddress proxyAddress, @Nullable ProxyType proxyType,
+                           @Nullable HostWithPort proxyAddress, @Nullable ProxyType proxyType,
                            @NonNull String nick, @NonNull String userString, @NonNull String realName, @NonNull ActorTracker actorTracker,
                            @NonNull AuthManager authManager, CapabilityManager.@NonNull WithManagement capabilityManager,
                            @NonNull EventManager eventManager, @NonNull List<EventListenerSupplier> listenerSuppliers,
@@ -540,7 +541,7 @@ public class DefaultClient implements Client.WithManagement {
     }
 
     @Override
-    public @NonNull InetSocketAddress getServerAddress() {
+    public @NonNull HostWithPort getServerAddress() {
         return this.serverAddress;
     }
 
@@ -550,7 +551,7 @@ public class DefaultClient implements Client.WithManagement {
     }
 
     @Override
-    public @NonNull Optional<InetSocketAddress> getProxyAddress() {
+    public @NonNull Optional<HostWithPort> getProxyAddress() {
         return Optional.ofNullable(this.proxyAddress);
     }
 
@@ -780,7 +781,7 @@ public class DefaultClient implements Client.WithManagement {
     }
 
     @Override
-    public void setServerAddress(@NonNull InetSocketAddress address) {
+    public void setServerAddress(@NonNull HostWithPort address) {
         this.serverAddress = address;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/feature/resolver/JavaResolver.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/resolver/JavaResolver.java
@@ -1,0 +1,46 @@
+/*
+ * * Copyright (C) 2013-2018 Matt Baxter https://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.feature.resolver;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * A slightly improved resolution design than the Java default (which always
+ * returns the first acquired, which is often the same.
+ */
+public class JavaResolver implements Resolver {
+    private int resolutionCount = 0;
+
+    @Override
+    public @NonNull InetAddress getAddress(@NonNull String host) throws UnknownHostException {
+        InetAddress[] addresses = InetAddress.getAllByName(host);
+        if (addresses.length == 0) {
+            throw new UnknownHostException(host);
+        }
+        return addresses[this.resolutionCount++ % addresses.length];
+    }
+}

--- a/src/main/java/org/kitteh/irc/client/library/feature/resolver/Resolver.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/resolver/Resolver.java
@@ -1,0 +1,44 @@
+/*
+ * * Copyright (C) 2013-2018 Matt Baxter https://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.feature.resolver;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * A resolver of hostnames.
+ */
+@FunctionalInterface
+public interface Resolver {
+    /**
+     * Gets the InetAddress for the given host, resolving as necessary.
+     *
+     * @param host host (IP or hostname)
+     * @return InetAddress for the given host
+     * @throws UnknownHostException if it can't be found
+     */
+    @NonNull InetAddress getAddress(@NonNull String host) throws UnknownHostException;
+}

--- a/src/main/java/org/kitteh/irc/client/library/feature/sts/MemoryStsMachine.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/sts/MemoryStsMachine.java
@@ -25,9 +25,8 @@ package org.kitteh.irc.client.library.feature.sts;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.kitteh.irc.client.library.Client;
+import org.kitteh.irc.client.library.util.HostWithPort;
 import org.kitteh.irc.client.library.util.Sanity;
-
-import java.net.InetSocketAddress;
 
 /**
  * "Memory" prefix to distinguish implementation class
@@ -71,8 +70,8 @@ public class MemoryStsMachine implements StsMachine {
             case STS_POLICY_CACHED:
             case STS_PRESENT_RECONNECTING:
                 this.client.isSecureConnection();
-                InetSocketAddress oldAddress = this.client.getServerAddress();
-                InetSocketAddress newAddress = new InetSocketAddress(oldAddress.getHostName(), Integer.parseInt(this.policy.getOptions().getOrDefault(StsPolicy.POLICY_OPTION_KEY_PORT, "6697")));
+                HostWithPort oldAddress = this.client.getServerAddress();
+                HostWithPort newAddress = HostWithPort.of(oldAddress.getHost(), Integer.parseInt(this.policy.getOptions().getOrDefault(StsPolicy.POLICY_OPTION_KEY_PORT, "6697")));
 
                 this.client.setServerAddress(newAddress);
                 break;

--- a/src/main/java/org/kitteh/irc/client/library/feature/sts/StsHandler.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/sts/StsHandler.java
@@ -31,9 +31,9 @@ import org.kitteh.irc.client.library.event.capabilities.CapabilitiesNewSupported
 import org.kitteh.irc.client.library.event.capabilities.CapabilitiesSupportedListEvent;
 import org.kitteh.irc.client.library.event.client.ClientConnectionEndedEvent;
 import org.kitteh.irc.client.library.exception.KittehServerMessageException;
+import org.kitteh.irc.client.library.util.HostWithPort;
 import org.kitteh.irc.client.library.util.StsUtil;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -120,7 +120,7 @@ public class StsHandler {
         // The spec says we have to update the expiry of the policy if it still exists
         // at disconnection time...
         // Do this by removing and re-adding.
-        String hostname = this.client.getServerAddress().getHostName();
+        String hostname = this.client.getServerAddress().getHost();
         final StsStorageManager storageManager = this.machine.getStorageManager();
         storageManager.getEntry(hostname).ifPresent(policy -> {
             long duration = Long.parseLong(policy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_DURATION));
@@ -131,7 +131,7 @@ public class StsHandler {
 
     private void handleStsCapability(CapabilityState sts, List<ServerMessage> originalMessages) {
         this.isSecure = this.client.isSecureConnection();
-        InetSocketAddress address = this.client.getServerAddress();
+        HostWithPort address = this.client.getServerAddress();
         if (!sts.getValue().isPresent()) {
             throw new KittehServerMessageException(originalMessages, "No value provided for sts capability.");
         }
@@ -193,7 +193,7 @@ public class StsHandler {
                 }
 
                 final StsStorageManager storageMan = this.machine.getStorageManager();
-                String hostname = this.client.getServerAddress().getHostName();
+                String hostname = this.client.getServerAddress().getHost();
 
                 // A duration of 0 means the policy expires immediately.
                 // This method can be used by servers to remove a previously set policy.

--- a/src/main/java/org/kitteh/irc/client/library/util/HostWithPort.java
+++ b/src/main/java/org/kitteh/irc/client/library/util/HostWithPort.java
@@ -1,0 +1,127 @@
+/*
+ * * Copyright (C) 2013-2018 Matt Baxter https://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.value.qual.IntRange;
+
+import java.util.Objects;
+
+/**
+ * A host and a port. A love story.
+ */
+public class HostWithPort {
+    /**
+     * Minimum acceptable port value: 0.
+     */
+    public static final int PORT_MIN = 0;
+    /**
+     * Maximum acceptable port value: 65535.
+     */
+    public static final int PORT_MAX = 65535;
+
+    /**
+     * Constructs a HostWithPort with the given host and port.
+     *
+     * @param host host
+     * @param port port
+     * @return a HostWithPort with the provided information
+     */
+    public static @NonNull HostWithPort of(@NonNull String host, @IntRange(from = PORT_MIN, to = PORT_MAX) int port) {
+        Sanity.nullCheck(host, "Host cannot be null");
+        Sanity.truthiness((port >= PORT_MIN) && (port <= PORT_MAX), port + " is not acceptable port number");
+        return new HostWithPort(host, port);
+    }
+
+    private final String host;
+    private final int port;
+
+    private HostWithPort(@NonNull String host, @IntRange(from = PORT_MIN, to = PORT_MAX) int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Gets the host.
+     *
+     * @return host
+     */
+    public @NonNull String getHost() {
+        return this.host;
+    }
+
+    /**
+     * Gets the port.
+     *
+     * @return port
+     */
+    public int getPort() {
+        return this.port;
+    }
+
+    /**
+     * Returns a new instance with the given host and this object's port.
+     *
+     * @param host new host
+     * @return new instance
+     */
+    public @NonNull HostWithPort withHost(@NonNull String host) {
+        return HostWithPort.of(host, this.port);
+    }
+
+    /**
+     * Returns a new instance with the given port and this object's host.
+     *
+     * @param port new port
+     * @return new instance
+     */
+    public @NonNull HostWithPort withPort(@IntRange(from = PORT_MIN, to = PORT_MAX) int port) {
+        return HostWithPort.of(this.host, port);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if ((other == null) || (this.getClass() != other.getClass())) {
+            return false;
+        }
+        final HostWithPort that = (HostWithPort) other;
+        return (this.port == that.port) && Objects.equals(this.host, that.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.host, this.port);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringer(this)
+                .add("host", this.host)
+                .add("port", this.port)
+                .toString();
+    }
+}

--- a/src/test/java/org/kitteh/irc/client/library/FakeClient.java
+++ b/src/test/java/org/kitteh/irc/client/library/FakeClient.java
@@ -27,6 +27,7 @@ import org.kitteh.irc.client.library.feature.sending.MessageSendingQueue;
 import org.kitteh.irc.client.library.feature.sts.StsMachine;
 import org.kitteh.irc.client.library.feature.sts.StsStorageManager;
 import org.kitteh.irc.client.library.util.Cutter;
+import org.kitteh.irc.client.library.util.HostWithPort;
 import org.kitteh.irc.client.library.util.Listener;
 import org.kitteh.irc.client.library.util.Pair;
 
@@ -72,13 +73,12 @@ public class FakeClient implements Client.WithManagement {
     }
 
     @Override
-    public void setServerAddress(@NonNull InetSocketAddress address) {
+    public void setServerAddress(@NonNull HostWithPort address) {
 
     }
 
     @Override
-    public void initialize(@NonNull String name, @NonNull InetSocketAddress serverAddress, @Nullable String serverPassword, @Nullable InetSocketAddress bindAddress, @Nullable InetSocketAddress proxyAddress, @Nullable ProxyType proxyType, @NonNull String nick, @NonNull String userString, @NonNull String realName, @NonNull ActorTracker actorTracker, @NonNull AuthManager authManager, CapabilityManager.@NonNull WithManagement capabilityManager, @NonNull EventManager eventManager, @NonNull List<EventListenerSupplier> listenerSuppliers, @NonNull MessageTagManager messageTagManager, @NonNull ISupportManager iSupportManager, @Nullable DefaultMessageMap defaultMessageMap, @NonNull Function<WithManagement, ? extends MessageSendingQueue> messageSendingQueue, @NonNull Function<WithManagement, ? extends ServerInfo.WithManagement> serverInfo, @Nullable Consumer<Exception> exceptionListener, @Nullable Consumer<String> inputListener, @Nullable Consumer<String> outputListener, boolean secure, @Nullable Path secureKeyCertChain, @Nullable Path secureKey, @Nullable String secureKeyPassword, @Nullable TrustManagerFactory trustManagerFactory, @Nullable StsStorageManager stsStorageManager, @Nullable String webircHost, @Nullable InetAddress webircIP, @Nullable String webircPassword, @Nullable String webircUser) {
-
+    public void initialize(@NonNull String name, @NonNull HostWithPort serverHostWithPort, @Nullable String serverPassword, @Nullable InetSocketAddress bindAddress, @Nullable HostWithPort proxyAddress, @Nullable ProxyType proxyType, @NonNull String nick, @NonNull String userString, @NonNull String realName, @NonNull ActorTracker actorTracker, @NonNull AuthManager authManager, CapabilityManager.@NonNull WithManagement capabilityManager, @NonNull EventManager eventManager, @NonNull List<EventListenerSupplier> listenerSuppliers, @NonNull MessageTagManager messageTagManager, @NonNull ISupportManager iSupportManager, @Nullable DefaultMessageMap defaultMessageMap, @NonNull Function<WithManagement, ? extends MessageSendingQueue> messageSendingQueue, @NonNull Function<WithManagement, ? extends ServerInfo.WithManagement> serverInfo, @Nullable Consumer<Exception> exceptionListener, @Nullable Consumer<String> inputListener, @Nullable Consumer<String> outputListener, boolean secure, @Nullable Path secureKeyCertChain, @Nullable Path secureKey, @Nullable String secureKeyPassword, @Nullable TrustManagerFactory trustManagerFactory, @Nullable StsStorageManager stsStorageManager, @Nullable String webircHost, @Nullable InetAddress webircIP, @Nullable String webircPassword, @Nullable String webircUser) {
     }
 
     @Override
@@ -211,7 +211,7 @@ public class FakeClient implements Client.WithManagement {
     }
 
     @Override
-    public @NonNull InetSocketAddress getServerAddress() {
+    public @NonNull HostWithPort getServerAddress() {
         return null;
     }
 
@@ -221,7 +221,7 @@ public class FakeClient implements Client.WithManagement {
     }
 
     @Override
-    public @NonNull Optional<InetSocketAddress> getProxyAddress() {
+    public @NonNull Optional<HostWithPort> getProxyAddress() {
         return Optional.empty();
     }
 


### PR DESCRIPTION
Crossed out items to come for 5.1.0:

1. Introduce new `HostWithPort` object.
   
   * Static method to create (`of(String, int)`).
   * Modifiers returning new instances.
2. Add new `Client.Builder.Server` method to use `HostWithPort`.
   
   * Keep String and int methods as well here.
3. Remove `InetSocketAddress` usage for server hosts from API, replace with `HostWithPort`.
4. Introduce new `Resolver` interface.
   
   * ~~Set in `Client.Builder`.~~
5. Introduce `Resolver` implementation that just does current Java-based resolution.
6. ~~Introduce `Resolver` implementation that utilizes `netty-resolver-dns`.~~
   
   * ~~Make this the default.~~