### PR TITLE
Batch support

### DIFF
--- a/src/main/java/org/kitteh/irc/client/library/event/abstractbase/ClientBatchEventBase.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/abstractbase/ClientBatchEventBase.java
@@ -21,36 +21,33 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.kitteh.irc.client.library.event.client;
+package org.kitteh.irc.client.library.event.abstractbase;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.element.Actor;
 import org.kitteh.irc.client.library.element.ServerMessage;
-import org.kitteh.irc.client.library.event.abstractbase.ClientReceiveServerMessageEventBase;
-import org.kitteh.irc.client.library.feature.filter.CommandFilter;
+import org.kitteh.irc.client.library.event.helper.BatchEvent;
+import org.kitteh.irc.client.library.util.BatchReferenceTag;
 
 import java.util.List;
 
-/**
- * Fires when the client receives a command message. Note that the client
- * itself listens to this event internally to fire events at an mBassador
- * priority of Integer.MAX_VALUE - 1. If you wish to beat the client to
- * listening to a command, listen at priority INTEGER.MAX_VALUE.
- *
- * @see CommandFilter
- */
-public class ClientReceiveCommandEvent extends ClientReceiveServerMessageEventBase {
+public class ClientBatchEventBase extends ServerMessageEventBase implements BatchEvent {
+    private final BatchReferenceTag tag;
+
     /**
      * Constructs the event.
      *
-     * @param client client
-     * @param serverMessage server message
-     * @param actor actor
-     * @param command command
-     * @param parameters parameters
+     * @param client the client
+     * @param originalMessages original messages
+     * @param batchReferenceTag reference-tag and associated information
      */
-    public ClientReceiveCommandEvent(@NonNull Client client, @NonNull ServerMessage serverMessage, @NonNull Actor actor, @NonNull String command, @NonNull List<String> parameters) {
-        super(client, serverMessage, actor, command, parameters);
+    public ClientBatchEventBase(@NonNull Client client, @NonNull List<ServerMessage> originalMessages, @NonNull BatchReferenceTag batchReferenceTag) {
+        super(client, originalMessages);
+        this.tag = batchReferenceTag;
+    }
+
+    @Override
+    public @NonNull BatchReferenceTag getReferenceTag() {
+        return this.tag;
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientBatchEndEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientBatchEndEvent.java
@@ -25,32 +25,24 @@ package org.kitteh.irc.client.library.event.client;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.element.Actor;
 import org.kitteh.irc.client.library.element.ServerMessage;
-import org.kitteh.irc.client.library.event.abstractbase.ClientReceiveServerMessageEventBase;
-import org.kitteh.irc.client.library.feature.filter.CommandFilter;
+import org.kitteh.irc.client.library.event.abstractbase.ClientBatchEventBase;
+import org.kitteh.irc.client.library.util.BatchReferenceTag;
 
 import java.util.List;
 
 /**
- * Fires when the client receives a command message. Note that the client
- * itself listens to this event internally to fire events at an mBassador
- * priority of Integer.MAX_VALUE - 1. If you wish to beat the client to
- * listening to a command, listen at priority INTEGER.MAX_VALUE.
- *
- * @see CommandFilter
+ * A batch has ended, and all the messages will now be processed.
  */
-public class ClientReceiveCommandEvent extends ClientReceiveServerMessageEventBase {
+public class ClientBatchEndEvent extends ClientBatchEventBase {
     /**
      * Constructs the event.
      *
-     * @param client client
-     * @param serverMessage server message
-     * @param actor actor
-     * @param command command
-     * @param parameters parameters
+     * @param client the client
+     * @param originalMessages original messages
+     * @param batchReferenceTag reference-tag and associated information
      */
-    public ClientReceiveCommandEvent(@NonNull Client client, @NonNull ServerMessage serverMessage, @NonNull Actor actor, @NonNull String command, @NonNull List<String> parameters) {
-        super(client, serverMessage, actor, command, parameters);
+    public ClientBatchEndEvent(@NonNull Client client, @NonNull List<ServerMessage> originalMessages, @NonNull BatchReferenceTag batchReferenceTag) {
+        super(client, originalMessages, batchReferenceTag);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientBatchMessageEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientBatchMessageEvent.java
@@ -25,32 +25,25 @@ package org.kitteh.irc.client.library.event.client;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.element.Actor;
 import org.kitteh.irc.client.library.element.ServerMessage;
-import org.kitteh.irc.client.library.event.abstractbase.ClientReceiveServerMessageEventBase;
-import org.kitteh.irc.client.library.feature.filter.CommandFilter;
+import org.kitteh.irc.client.library.event.abstractbase.ClientBatchEventBase;
+import org.kitteh.irc.client.library.util.BatchReferenceTag;
 
 import java.util.List;
 
 /**
- * Fires when the client receives a command message. Note that the client
- * itself listens to this event internally to fire events at an mBassador
- * priority of Integer.MAX_VALUE - 1. If you wish to beat the client to
- * listening to a command, listen at priority INTEGER.MAX_VALUE.
- *
- * @see CommandFilter
+ * A new message has been added to a batch reference tag, and will be held
+ * until the batch finishes.
  */
-public class ClientReceiveCommandEvent extends ClientReceiveServerMessageEventBase {
+public class ClientBatchMessageEvent extends ClientBatchEventBase {
     /**
      * Constructs the event.
      *
-     * @param client client
-     * @param serverMessage server message
-     * @param actor actor
-     * @param command command
-     * @param parameters parameters
+     * @param client the client
+     * @param originalMessages original messages
+     * @param batchReferenceTag reference-tag and associated information
      */
-    public ClientReceiveCommandEvent(@NonNull Client client, @NonNull ServerMessage serverMessage, @NonNull Actor actor, @NonNull String command, @NonNull List<String> parameters) {
-        super(client, serverMessage, actor, command, parameters);
+    public ClientBatchMessageEvent(@NonNull Client client, @NonNull List<ServerMessage> originalMessages, @NonNull BatchReferenceTag batchReferenceTag) {
+        super(client, originalMessages, batchReferenceTag);
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientBatchStartEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientBatchStartEvent.java
@@ -25,32 +25,47 @@ package org.kitteh.irc.client.library.event.client;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.kitteh.irc.client.library.Client;
-import org.kitteh.irc.client.library.element.Actor;
 import org.kitteh.irc.client.library.element.ServerMessage;
-import org.kitteh.irc.client.library.event.abstractbase.ClientReceiveServerMessageEventBase;
-import org.kitteh.irc.client.library.feature.filter.CommandFilter;
+import org.kitteh.irc.client.library.event.abstractbase.ClientBatchEventBase;
+import org.kitteh.irc.client.library.util.BatchReferenceTag;
 
 import java.util.List;
 
 /**
- * Fires when the client receives a command message. Note that the client
- * itself listens to this event internally to fire events at an mBassador
- * priority of Integer.MAX_VALUE - 1. If you wish to beat the client to
- * listening to a command, listen at priority INTEGER.MAX_VALUE.
- *
- * @see CommandFilter
+ * A batch has started.
  */
-public class ClientReceiveCommandEvent extends ClientReceiveServerMessageEventBase {
+public class ClientBatchStartEvent extends ClientBatchEventBase {
+    private boolean ignore = false;
+
     /**
      * Constructs the event.
      *
-     * @param client client
-     * @param serverMessage server message
-     * @param actor actor
-     * @param command command
-     * @param parameters parameters
+     * @param client the client
+     * @param originalMessages original messages
+     * @param batchReferenceTag reference-tag and associated information
      */
-    public ClientReceiveCommandEvent(@NonNull Client client, @NonNull ServerMessage serverMessage, @NonNull Actor actor, @NonNull String command, @NonNull List<String> parameters) {
-        super(client, serverMessage, actor, command, parameters);
+    public ClientBatchStartEvent(@NonNull Client client, @NonNull List<ServerMessage> originalMessages, @NonNull BatchReferenceTag batchReferenceTag) {
+        super(client, originalMessages, batchReferenceTag);
+    }
+
+    /**
+     * Gets if the reference tag will be ignored, resulting in tagged messages
+     * being processed as if the batch tag were not holding them back.
+     *
+     * @return true if the tag will be ignored
+     * @see #setReferenceTagIgnored(boolean)
+     */
+    public boolean isReferenceTagIgnored() {
+        return this.ignore;
+    }
+
+    /**
+     * Sets if the reference tag will be ignored, resulting in tagged messages
+     * being processed as if the batch tag were not holding them back.
+     *
+     * @param ignore true to ignore the tag
+     */
+    public void setReferenceTagIgnored(boolean ignore) {
+        this.ignore = ignore;
     }
 }

--- a/src/main/java/org/kitteh/irc/client/library/event/client/ClientReceiveNumericEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/client/ClientReceiveNumericEvent.java
@@ -51,10 +51,10 @@ public class ClientReceiveNumericEvent extends ClientReceiveServerMessageEventBa
      * @param server server
      * @param command command
      * @param numeric numeric
-     * @param args args
+     * @param parameters parameters
      */
-    public ClientReceiveNumericEvent(@NonNull Client client, @NonNull ServerMessage serverMessage, @NonNull Actor server, String command, int numeric, @NonNull List<String> args) {
-        super(client, serverMessage, server, command, args);
+    public ClientReceiveNumericEvent(@NonNull Client client, @NonNull ServerMessage serverMessage, @NonNull Actor server, String command, int numeric, @NonNull List<String> parameters) {
+        super(client, serverMessage, server, command, parameters);
         this.numeric = numeric;
     }
 

--- a/src/main/java/org/kitteh/irc/client/library/event/helper/BatchEvent.java
+++ b/src/main/java/org/kitteh/irc/client/library/event/helper/BatchEvent.java
@@ -1,0 +1,34 @@
+/*
+ * * Copyright (C) 2013-2019 Matt Baxter https://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.event.helper;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.kitteh.irc.client.library.util.BatchReferenceTag;
+
+/**
+ * An event involving batched messages.
+ */
+public interface BatchEvent extends ServerMessageEvent {
+    @NonNull BatchReferenceTag getReferenceTag();
+}

--- a/src/main/java/org/kitteh/irc/client/library/feature/CapabilityManager.java
+++ b/src/main/java/org/kitteh/irc/client/library/feature/CapabilityManager.java
@@ -82,6 +82,11 @@ public interface CapabilityManager {
         public static final String AWAY_NOTIFY = "away-notify";
 
         /**
+         * Batched messages.
+         */
+        public static final String BATCH = "batch";
+
+        /**
          * Capability change notification. Implicitly enabled by the server
          * when "CAP LS 302" (or higher version) is sent and therefore it
          * is not requested by the default capability manager.

--- a/src/main/java/org/kitteh/irc/client/library/util/BatchReferenceTag.java
+++ b/src/main/java/org/kitteh/irc/client/library/util/BatchReferenceTag.java
@@ -1,0 +1,110 @@
+/*
+ * * Copyright (C) 2013-2019 Matt Baxter https://kitteh.org
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.kitteh.irc.client.library.util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.kitteh.irc.client.library.event.helper.ClientReceiveServerMessageEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Represents a BATCH capability reference tag.
+ */
+public class BatchReferenceTag {
+    private final String referenceTag;
+    private final String batchType;
+    private final List<String> batchTypeParameters;
+    private final List<ClientReceiveServerMessageEvent> events = new CopyOnWriteArrayList<>();
+
+    /**
+     * Constructs a reference tag.
+     *
+     * @param referenceTag the tag
+     * @param type the tag's type
+     * @param parameters any additional parameters
+     */
+    public BatchReferenceTag(@NonNull String referenceTag, @NonNull String type, @NonNull List<String> parameters) {
+        this.referenceTag = referenceTag;
+        this.batchType = type;
+        this.batchTypeParameters = Collections.unmodifiableList(parameters);
+    }
+
+    /**
+     * Constructs a reference tag without parameters.
+     *
+     * @param referenceTag the tag
+     * @param type the tag's type
+     */
+    public BatchReferenceTag(@NonNull String referenceTag, @NonNull String type) {
+        this(referenceTag, type, Collections.emptyList());
+    }
+
+    /**
+     * Gets the reference tag.
+     *
+     * @return the tag name
+     */
+    public @NonNull String getReferenceTag() {
+        return this.referenceTag;
+    }
+
+    /**
+     * Gets the tag's type
+     *
+     * @return type
+     */
+    public @NonNull String getType() {
+        return this.batchType;
+    }
+
+    /**
+     * Gets the tag's parameters.
+     *
+     * @return parameters or an empty list if there aren't any
+     */
+    public @NonNull List<String> getParameters() {
+        return this.batchTypeParameters;
+    }
+
+    /**
+     * Gets the events, in order, assigned to this tag.
+     *
+     * @return events
+     */
+    public @NonNull List<ClientReceiveServerMessageEvent> getEvents() {
+        return Collections.unmodifiableList(new ArrayList<>(this.events));
+    }
+
+    /**
+     * Adds an event to the tag.
+     *
+     * @param event event to add
+     */
+    public void addEvent(@NonNull ClientReceiveServerMessageEvent event) {
+        this.events.add(event);
+    }
+}


### PR DESCRIPTION
Added support for IRCv3 batch:

* Added events for a batch starting, adding messages to a batch, and a batch finishing.
* Batched messages now supported by default. Client will not process batched messages until the declared end of a batch.
* Renamed dobby boolean because it was causing too much confusion in reading.