### PR TITLE
Migrate tests to modern JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/kitteh/irc/client/library/CapabilityManagerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/CapabilityManagerTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.element.CapabilityState;
 import org.kitteh.irc.client.library.feature.CapabilityManager;
 
@@ -23,11 +23,11 @@ public class CapabilityManagerTest {
     @Test
     public void testDefaultGetCapabilityMethodsInCapabilityManager() {
         StubCapabilityManager sut = new StubCapabilityManager();
-        Assert.assertEquals(2, sut.getCapabilities().size());
-        Assert.assertTrue(sut.getCapability("Test1").isPresent());
-        Assert.assertTrue(sut.getSupportedCapability("Test1").isPresent());
-        Assert.assertFalse(sut.getSupportedCapability("Test2").isPresent());
-        Assert.assertFalse(sut.getCapability("Cats").isPresent());
+        Assertions.assertEquals(2, sut.getCapabilities().size());
+        Assertions.assertTrue(sut.getCapability("Test1").isPresent());
+        Assertions.assertTrue(sut.getSupportedCapability("Test1").isPresent());
+        Assertions.assertFalse(sut.getSupportedCapability("Test2").isPresent());
+        Assertions.assertFalse(sut.getCapability("Cats").isPresent());
     }
 
     /**
@@ -36,8 +36,8 @@ public class CapabilityManagerTest {
     @Test
     public void testNativeCapabilityRetrieval() {
         List<String> caps = CapabilityManager.Defaults.getDefaults();
-        Assert.assertFalse(caps.isEmpty());
-        Assert.assertTrue(caps.contains(CapabilityManager.Defaults.ACCOUNT_NOTIFY));
+        Assertions.assertFalse(caps.isEmpty());
+        Assertions.assertTrue(caps.contains(CapabilityManager.Defaults.ACCOUNT_NOTIFY));
     }
 
     /**
@@ -48,7 +48,7 @@ public class CapabilityManagerTest {
     @Test
     public void testConstructorIsPrivate() throws Exception {
         Constructor<CapabilityManager.Defaults> constructor = CapabilityManager.Defaults.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assertions.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }

--- a/src/test/java/org/kitteh/irc/client/library/CaseMappingTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/CaseMappingTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.feature.CaseMapping;
 import org.kitteh.irc.client.library.util.Pair;
 
@@ -20,10 +20,10 @@ public class CaseMappingTest {
     public void verifyMatch() {
         for (CaseMapping caseMapping : CaseMapping.values()) {
             Optional<CaseMapping> acquired = CaseMapping.getByName(caseMapping.name().replace('_', '-'));
-            Assert.assertTrue("Failed to acquire mapping for " + caseMapping.name(), acquired.isPresent());
-            Assert.assertEquals(caseMapping, acquired.get());
+            Assertions.assertTrue(acquired.isPresent(), "Failed to acquire mapping for " + caseMapping.name());
+            Assertions.assertEquals(caseMapping, acquired.get());
         }
-        Assert.assertEquals(Optional.empty(), CaseMapping.getByName(null));
+        Assertions.assertEquals(Optional.empty(), CaseMapping.getByName(null));
     }
 
     /**
@@ -37,11 +37,11 @@ public class CaseMappingTest {
         test.put(CaseMapping.STRICT_RFC1459, new Pair<>("abcdwxyzABCDWXYZ!@#$%^&*(){}[];':,.<>", "abcdwxyzabcdwxyz!@#$%^&*(){}{};':,.<>"));
 
         for (CaseMapping caseMapping : CaseMapping.values()) {
-            Assert.assertTrue("Missing CaseMapping " + caseMapping.name(), test.containsKey(caseMapping));
+            Assertions.assertTrue(test.containsKey(caseMapping), "Missing CaseMapping " + caseMapping.name());
         }
         for (Map.Entry<CaseMapping, Pair<String, String>> entry : test.entrySet()) {
-            Assert.assertEquals("Incorrect lowercasing", entry.getKey().toLowerCase(entry.getValue().getLeft()), entry.getValue().getRight());
-            Assert.assertTrue("Incorrect equalsIgnoreCase", entry.getKey().areEqualIgnoringCase(entry.getValue().getLeft(), entry.getValue().getRight()));
+            Assertions.assertEquals(entry.getKey().toLowerCase(entry.getValue().getLeft()), entry.getValue().getRight(), "Incorrect lowercasing");
+            Assertions.assertTrue(entry.getKey().areEqualIgnoringCase(entry.getValue().getLeft(), entry.getValue().getRight()), "Incorrect equalsIgnoreCase");
         }
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/DefaultBuilderTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/DefaultBuilderTest.java
@@ -1,6 +1,6 @@
 package org.kitteh.irc.client.library;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test building a builder.

--- a/src/test/java/org/kitteh/irc/client/library/FormatTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/FormatTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.util.Format;
 
 /**
@@ -13,31 +13,31 @@ public class FormatTest {
      */
     @Test
     public void background() {
-        Assert.assertEquals("\u000309,01", Format.GREEN.withBackground(Format.BLACK));
+        Assertions.assertEquals("\u000309,01", Format.GREEN.withBackground(Format.BLACK));
     }
 
     /**
      * Tests invalid background input.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void backgroundNonColorBackground() {
-        Format.GREEN.withBackground(Format.BOLD);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Format.GREEN.withBackground(Format.BOLD));
     }
 
     /**
      * Tests invalid background input.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void backgroundNonColorForeground() {
-        Format.BOLD.withBackground(Format.GREEN);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Format.BOLD.withBackground(Format.GREEN));
     }
 
     /**
      * Tests invalid background input.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void backgroundNull() {
-        Format.GREEN.withBackground(null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Format.GREEN.withBackground(null));
     }
 
     /**
@@ -47,7 +47,7 @@ public class FormatTest {
     public void format() {
         String colorChar = Format.COLOR_CHAR + "";
         for (Format format : Format.values()) {
-            Assert.assertTrue("Color format with wrong length: " + format.name(), !format.toString().startsWith(colorChar) || (format.toString().length() == 3));
+            Assertions.assertTrue(!format.toString().startsWith(colorChar) || (format.toString().length() == 3), "Color format with wrong length: " + format.name());
         }
     }
 
@@ -56,8 +56,8 @@ public class FormatTest {
      */
     @Test
     public void stripColor() {
-        Assert.assertEquals(Format.stripColor(Format.GREEN + "meow"), "meow");
-        Assert.assertEquals(Format.stripColor(Format.BOLD + "purr"), Format.BOLD + "purr");
+        Assertions.assertEquals(Format.stripColor(Format.GREEN + "meow"), "meow");
+        Assertions.assertEquals(Format.stripColor(Format.BOLD + "purr"), Format.BOLD + "purr");
     }
 
     /**
@@ -65,8 +65,8 @@ public class FormatTest {
      */
     @Test
     public void stripFormat() {
-        Assert.assertEquals(Format.stripFormatting(Format.GREEN + "meow"), Format.GREEN + "meow");
-        Assert.assertEquals(Format.stripFormatting(Format.BOLD + "purr"), "purr");
+        Assertions.assertEquals(Format.stripFormatting(Format.GREEN + "meow"), Format.GREEN + "meow");
+        Assertions.assertEquals(Format.stripFormatting(Format.BOLD + "purr"), "purr");
     }
 
     /**
@@ -76,9 +76,9 @@ public class FormatTest {
     public void validColors() {
         for (Format format : Format.values()) {
             if (format.isColor()) {
-                Assert.assertEquals("Invalid IRCFormat color char " + format.name(), (format.getColorChar() & 15), format.getColorChar());
+                Assertions.assertEquals((format.getColorChar() & 15), format.getColorChar(), "Invalid IRCFormat color char " + format.name());
             } else {
-                Assert.assertEquals("Invalid IRCFormat format " + format.name(), format.getColorChar(), -1);
+                Assertions.assertEquals(format.getColorChar(), -1, "Invalid IRCFormat format " + format.name());
             }
         }
     }

--- a/src/test/java/org/kitteh/irc/client/library/command/AwayCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/AwayCommandTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.mockito.Mockito;
 
@@ -65,7 +65,7 @@ public class AwayCommandTest {
         awayCommand.away(MESSAGE);
         awayCommand.execute();
 
-        Assert.assertTrue(awayCommand.toString().contains(MESSAGE));
+        Assertions.assertTrue(awayCommand.toString().contains(MESSAGE));
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/command/CapabilityRequestCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/CapabilityRequestCommandTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.mockito.Mockito;
 
@@ -83,7 +83,7 @@ public class CapabilityRequestCommandTest {
         sut.enable("testCapability");
 
         // assert
-        Assert.assertEquals("CapabilityRequestCommand (client=testClientToString, requests=[testCapability])", sut.toString());
+        Assertions.assertEquals("CapabilityRequestCommand (client=testClientToString, requests=[testCapability])", sut.toString());
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/command/ChannelModeCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/ChannelModeCommandTest.java
@@ -1,9 +1,9 @@
 package org.kitteh.irc.client.library.command;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.element.Channel;
 import org.kitteh.irc.client.library.element.ISupportParameter;
@@ -29,7 +29,7 @@ public class ChannelModeCommandTest {
     /**
      * And then Kitteh said, let there be test!
      */
-    @Before
+    @BeforeEach
     public void before() {
         this.client = Mockito.mock(Client.class);
         Mockito.when(this.client.getChannel(CHANNEL)).thenReturn(Optional.of(Mockito.mock(Channel.class)));
@@ -47,7 +47,7 @@ public class ChannelModeCommandTest {
         sut.execute();
         Mockito.verify(this.client, Mockito.times(1)).sendRawLine("MODE " + CHANNEL);
 
-        Assert.assertFalse(sut.toString().isEmpty());
+        Assertions.assertFalse(sut.toString().isEmpty());
     }
 
     @Test
@@ -96,11 +96,11 @@ public class ChannelModeCommandTest {
         inOrder.verify(this.client, Mockito.times(1)).sendRawLine("MODE " + CHANNEL + " +D meow");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithOneSimpleModeChangeButWrongClient() {
         ChannelModeCommand sut = new ChannelModeCommand(this.client, CHANNEL);
         ChannelMode mode = this.getChannelMode('A', Mockito.mock(Client.class), ChannelMode.Type.A_MASK);
-        sut.add(ModeStatus.Action.ADD, mode);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.add(ModeStatus.Action.ADD, mode));
     }
 
     @Test
@@ -148,14 +148,14 @@ public class ChannelModeCommandTest {
         Mockito.verify(this.client, Mockito.times(1)).sendRawLine("MODE " + CHANNEL + " +A kitteh");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddModeWithParameterViaUserButWrongClient() {
         User userMock = Mockito.mock(User.class);
         Mockito.when(userMock.getClient()).thenReturn(Mockito.mock(Client.class));
         Mockito.when(userMock.getNick()).thenReturn("kitteh");
         ChannelModeCommand sut = new ChannelModeCommand(this.client, CHANNEL);
         ChannelUserMode mode = this.getChannelUserMode('A', this.client, ChannelMode.Type.B_PARAMETER_ALWAYS);
-        sut.add(ModeStatus.Action.ADD, mode, userMock);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.add(ModeStatus.Action.ADD, mode, userMock));
     }
 
     @Test

--- a/src/test/java/org/kitteh/irc/client/library/command/KickCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/KickCommandTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.defaults.feature.SimpleDefaultMessageMap;
 import org.kitteh.irc.client.library.element.User;
@@ -23,7 +23,7 @@ public class KickCommandTest {
     /**
      * And then Kitteh said, let there be test!
      */
-    @Before
+    @BeforeEach
     public void before() {
         this.client = Mockito.mock(Client.class);
         ServerInfo serverInfo = Mockito.mock(ServerInfo.class);
@@ -79,21 +79,21 @@ public class KickCommandTest {
     /**
      * Tests a targetless execution.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void noTarget() {
         KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.execute();
+        Assertions.assertThrowsExactly(IllegalStateException.class, command::execute);
     }
 
     /**
      * Tests a wrong-Client attempt.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void wrongClientUser() {
         Mockito.when(this.user.getClient()).thenReturn(Mockito.mock(Client.class));
 
         KickCommand command = new KickCommand(this.client, CHANNEL);
-        command.target(this.user);
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> command.target(this.user));
     }
 
     /**
@@ -103,6 +103,6 @@ public class KickCommandTest {
     public void toStringer() {
         KickCommand command = new KickCommand(this.client, CHANNEL);
 
-        Assert.assertTrue(command.toString().contains(CHANNEL));
+        Assertions.assertTrue(command.toString().contains(CHANNEL));
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/command/MonitorCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/MonitorCommandTest.java
@@ -1,6 +1,7 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.mockito.Mockito;
 
@@ -62,20 +63,20 @@ public class MonitorCommandTest {
     /**
      * Tests a targetless failure.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testAddNoTarget() {
         Client ircClient = getClientMock();
         MonitorCommand command = new MonitorCommand(ircClient);
 
         command.action(MonitorCommand.Action.ADD_TARGET);
 
-        command.execute();
+        Assertions.assertThrows(IllegalStateException.class, command::execute);
     }
 
     /**
      * Tests a targetless failure.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testAddNoTarget2() {
         Client ircClient = getClientMock();
         MonitorCommand command = new MonitorCommand(ircClient);
@@ -83,31 +84,31 @@ public class MonitorCommandTest {
         command.action(MonitorCommand.Action.ADD_TARGET);
         command.target();
 
-        command.execute();
+        Assertions.assertThrows(IllegalStateException.class, command::execute);
     }
 
     /**
      * Tests invalid target input.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidTarget() {
         Client ircClient = getClientMock();
         MonitorCommand command = new MonitorCommand(ircClient);
 
-        command.target("meow,", "purr");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> command.target("meow,", "purr"));
     }
 
     /**
      * Tests an actionless execution.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testAddNoAction() {
         Client ircClient = getClientMock();
         MonitorCommand command = new MonitorCommand(ircClient);
 
         command.target("meow", "purr");
 
-        command.execute();
+        Assertions.assertThrows(IllegalStateException.class, command::execute);
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/command/OperCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/OperCommandTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.mockito.Mockito;
 
@@ -38,30 +38,30 @@ public class OperCommandTest {
         command.user(USER);
         command.password(PASSWORD);
 
-        Assert.assertFalse("Details in toString", command.toString().contains(USER) || command.toString().contains(PASSWORD));
+        Assertions.assertFalse(command.toString().contains(USER) || command.toString().contains(PASSWORD), "Details in toString");
     }
 
     /**
      * Tests a userless execution.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void noUser() {
         Client client = Mockito.mock(Client.class);
 
         OperCommand command = new OperCommand(client);
         command.password(PASSWORD);
-        command.execute();
+        Assertions.assertThrows(IllegalStateException.class, command::execute);
     }
 
     /**
      * Tests a passless execution.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void noPass() {
         Client client = Mockito.mock(Client.class);
 
         OperCommand command = new OperCommand(client);
         command.user(USER);
-        command.execute();
+        Assertions.assertThrows(IllegalStateException.class, command::execute);
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/command/TopicCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/TopicCommandTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.feature.ServerInfo;
 import org.mockito.Mockito;
@@ -19,7 +19,7 @@ public class TopicCommandTest {
     /**
      * And then Kitteh said, let there be test!
      */
-    @Before
+    @BeforeEach
     public void before() {
         this.client = Mockito.mock(Client.class);
         ServerInfo serverInfo = Mockito.mock(ServerInfo.class);
@@ -73,7 +73,7 @@ public class TopicCommandTest {
         topicCommand.topic(TOPIC);
         topicCommand.execute();
 
-        Assert.assertTrue(topicCommand.toString().contains(TOPIC));
+        Assertions.assertTrue(topicCommand.toString().contains(TOPIC));
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/command/UserModeCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/UserModeCommandTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.command;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.element.mode.ModeStatus;
 import org.kitteh.irc.client.library.element.mode.UserMode;
@@ -24,7 +24,7 @@ public class UserModeCommandTest {
         sut.execute();
         Mockito.verify(clientMock, Mockito.times(1)).sendRawLine("MODE " + USER);
 
-        Assert.assertFalse(sut.toString().isEmpty());
+        Assertions.assertFalse(sut.toString().isEmpty());
     }
 
     @Test
@@ -54,14 +54,14 @@ public class UserModeCommandTest {
         inOrder.verify(clientMock, Mockito.times(1)).sendRawLine("MODE " + USER + " +ABCD");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithOneSimpleModeChangeButWrongClient() {
         Client clientMock = Mockito.mock(Client.class);
         Mockito.when(clientMock.getNick()).thenReturn(USER);
 
         UserModeCommand sut = new UserModeCommand(clientMock);
         UserMode mode = this.getUserMode('A', Mockito.mock(Client.class));
-        sut.add(ModeStatus.Action.ADD, mode);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.add(ModeStatus.Action.ADD, mode));
     }
 
     @Test

--- a/src/test/java/org/kitteh/irc/client/library/command/WallopsCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/WallopsCommandTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.mockito.Mockito;
 
@@ -35,17 +35,17 @@ public class WallopsCommandTest {
         WallopsCommand command = new WallopsCommand(client);
         command.message(MESSAGE);
 
-        Assert.assertTrue("toString missing message", command.toString().contains(MESSAGE));
+        Assertions.assertTrue(command.toString().contains(MESSAGE), "toString missing message");
     }
 
     /**
      * Tests a messageless execution.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void noUser() {
         Client client = Mockito.mock(Client.class);
 
         WallopsCommand command = new WallopsCommand(client);
-        command.execute();
+        Assertions.assertThrows(IllegalStateException.class, command::execute);
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/command/WhoisCommandTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/command/WhoisCommandTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.command;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.mockito.Mockito;
 
@@ -29,12 +29,12 @@ public class WhoisCommandTest {
     /**
      * Tests a simple mistake.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testNoNothing() {
         Client client = Mockito.mock(Client.class);
 
         WhoisCommand whoisCommand = new WhoisCommand(client);
-        whoisCommand.execute();
+        Assertions.assertThrows(IllegalStateException.class, whoisCommand::execute);
     }
 
     /**
@@ -78,6 +78,6 @@ public class WhoisCommandTest {
         WhoisCommand whoisCommand = new WhoisCommand(client);
         whoisCommand.target(TARGET);
 
-        Assert.assertTrue(whoisCommand.toString().contains(TARGET));
+        Assertions.assertTrue(whoisCommand.toString().contains(TARGET));
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/defaults/DefaultEventListenerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/DefaultEventListenerTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.defaults;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.defaults.element.DefaultServerMessage;
 import org.kitteh.irc.client.library.defaults.feature.DefaultActorTracker;
@@ -42,7 +42,7 @@ public class DefaultEventListenerTest {
     /**
      * And then Kitteh said, let there be test!
      */
-    @Before
+    @BeforeEach
     public void before() {
         this.client = Mockito.mock(Client.WithManagement.class);
         this.actorTracker = new DefaultActorTracker(this.client);

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/AuthManagerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/AuthManagerTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.defaults.feature;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.FakeClient;
 import org.kitteh.irc.client.library.feature.auth.AuthProtocol;
@@ -18,11 +18,11 @@ public class AuthManagerTest {
     /**
      * Tests a null protocol failure.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFailureWithNullProtocol() {
         Client client = new FakeClient();
         DefaultAuthManager sut = new DefaultAuthManager(client);
-        sut.addProtocol(null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.addProtocol(null));
     }
 
     /**
@@ -44,12 +44,12 @@ public class AuthManagerTest {
             }
         };
         sut.addProtocol(ap);
-        Assert.assertEquals(1, sut.getProtocols().size());
-        Assert.assertEquals(ap, sut.getProtocols().iterator().next());
-        Assert.assertFalse(sut.toString().isEmpty());
+        Assertions.assertEquals(1, sut.getProtocols().size());
+        Assertions.assertEquals(ap, sut.getProtocols().iterator().next());
+        Assertions.assertFalse(sut.toString().isEmpty());
         sut.removeProtocol(ap);
-        Assert.assertEquals(0, sut.getProtocols().size());
-        Assert.assertFalse(sut.getProtocols().iterator().hasNext());
+        Assertions.assertEquals(0, sut.getProtocols().size());
+        Assertions.assertFalse(sut.getProtocols().iterator().hasNext());
     }
 
     /**
@@ -63,8 +63,8 @@ public class AuthManagerTest {
         sut.addProtocol(stub1);
         StubAuthProtocol stub2 = new StubAuthProtocol();
         final Optional<AuthProtocol> ret = sut.addProtocol(stub2);
-        Assert.assertTrue(ret.isPresent());
-        Assert.assertSame(ret.get(), stub1);
+        Assertions.assertTrue(ret.isPresent());
+        Assertions.assertSame(ret.get(), stub1);
         Optional<AuthProtocol> removed = sut.addProtocol(new AuthProtocol() {
             @Override
             public @NonNull Client getClient() {
@@ -76,7 +76,7 @@ public class AuthManagerTest {
                 // do nothing
             }
         });
-        Assert.assertFalse(removed.isPresent());
+        Assertions.assertFalse(removed.isPresent());
     }
 
     /**
@@ -89,7 +89,7 @@ public class AuthManagerTest {
         final StubAuthProtocol stub = new StubAuthProtocol();
         sut.addProtocol(stub);
         sut.removeProtocol(stub);
-        Assert.assertTrue(stub.wasTripped());
+        Assertions.assertTrue(stub.wasTripped());
     }
 
     private class StubAuthProtocol implements AuthProtocol, EventListening {

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/ChghostTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/ChghostTest.java
@@ -1,8 +1,9 @@
 package org.kitteh.irc.client.library.defaults.feature;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.defaults.element.DefaultUser;
 import org.kitteh.irc.client.library.defaults.listener.DefaultChgHostListener;
@@ -39,9 +40,9 @@ public class ChghostTest {
         final Actor actorMock = Mockito.mock(Actor.class);
         Mockito.when(actorMock.getClient()).thenReturn(clientMock);
         sut.chghost(new ClientReceiveCommandEvent(clientMock, Mockito.mock(ServerMessage.class), actorMock, "CHGHOST", Arrays.asList("foo", "bar")));
-        Assert.assertEquals("No exception fired", 1, exceptions.size());
-        Assert.assertEquals("Wrong exception type", KittehServerMessageException.class, exceptions.get(0).getClass());
-        Assert.assertThat("Wrong exception fired", exceptions.get(0).getMessage(), CoreMatchers.containsString("Invalid actor for CHGHOST message"));
+        Assertions.assertEquals(1, exceptions.size(), "No exception fired");
+        Assertions.assertEquals(KittehServerMessageException.class, exceptions.get(0).getClass(), "Wrong exception type");
+        MatcherAssert.assertThat("Wrong exception fired", exceptions.get(0).getMessage(), CoreMatchers.containsString("Invalid actor for CHGHOST message"));
     }
 
     /**
@@ -55,9 +56,9 @@ public class ChghostTest {
         final Actor actorMock = Mockito.mock(User.class);
         Mockito.when(actorMock.getClient()).thenReturn(clientMock);
         sut.chghost(new ClientReceiveCommandEvent(clientMock, Mockito.mock(ServerMessage.class), actorMock, "CHGHOST", Arrays.asList("foo", "bar", "kitten")));
-        Assert.assertEquals("No exception fired", 1, exceptions.size());
-        Assert.assertEquals("Wrong exception type", KittehServerMessageException.class, exceptions.get(0).getClass());
-        Assert.assertThat("Wrong exception fired", exceptions.get(0).getMessage(), CoreMatchers.containsString("Invalid number of parameters for CHGHOST message"));
+        Assertions.assertEquals(1, exceptions.size(), "No exception fired");
+        Assertions.assertEquals(KittehServerMessageException.class, exceptions.get(0).getClass(), "Wrong exception type");
+        MatcherAssert.assertThat("Wrong exception fired", exceptions.get(0).getMessage(), CoreMatchers.containsString("Invalid number of parameters for CHGHOST message"));
     }
 
     /**
@@ -71,9 +72,9 @@ public class ChghostTest {
         final Actor actorMock = Mockito.mock(User.class);
         Mockito.when(actorMock.getClient()).thenReturn(clientMock);
         sut.chghost(new ClientReceiveCommandEvent(clientMock, Mockito.mock(ServerMessage.class), actorMock, "CHGHOST", Collections.singletonList("foo")));
-        Assert.assertEquals("No exception fired", 1, exceptions.size());
-        Assert.assertEquals("Wrong exception type", KittehServerMessageException.class, exceptions.get(0).getClass());
-        Assert.assertThat("Wrong exception fired", exceptions.get(0).getMessage(), CoreMatchers.containsString("Invalid number of parameters for CHGHOST message"));
+        Assertions.assertEquals(1, exceptions.size(), "No exception fired");
+        Assertions.assertEquals(KittehServerMessageException.class, exceptions.get(0).getClass(), "Wrong exception type");
+        MatcherAssert.assertThat("Wrong exception fired", exceptions.get(0).getMessage(), CoreMatchers.containsString("Invalid number of parameters for CHGHOST message"));
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/CustomEventManagerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/CustomEventManagerTest.java
@@ -3,8 +3,8 @@ package org.kitteh.irc.client.library.defaults.feature;
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.listener.Handler;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.FakeClient;
 import org.kitteh.irc.client.library.defaults.element.DefaultActor;
 import org.kitteh.irc.client.library.defaults.element.DefaultServerMessage;
@@ -72,8 +72,8 @@ public class CustomEventManagerTest {
         em.registerEventListener(this);
         em.callEvent(new ClientReceiveNumericEvent(client, new DefaultServerMessage.NumericCommand(200, "", Collections.emptyList()), actor, "", 200, Collections.emptyList()));
         em.callEvent(new ClientReceiveNumericEvent(client, new DefaultServerMessage.NumericCommand(300, "", Collections.emptyList()), actor, "", 300, Collections.emptyList()));
-        Assert.assertEquals(2, unfilteredNumericCount.get());
-        Assert.assertEquals(1, filteredNumericCount.get());
+        Assertions.assertEquals(2, unfilteredNumericCount.get());
+        Assertions.assertEquals(1, filteredNumericCount.get());
     }
 
     @Handler

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/EventTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/EventTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.defaults.feature;
 
 import net.engio.mbassy.listener.Handler;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.FakeClient;
 import org.kitteh.irc.client.library.feature.EventManager;
 
@@ -24,7 +24,7 @@ public class EventTest {
         manager.registerEventListener(this);
         Event event = new Event();
         manager.callEvent(event);
-        Assert.assertTrue("Failed to register and fire an event", event.success);
+        Assertions.assertTrue(event.success, "Failed to register and fire an event");
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/ISupportManagerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/ISupportManagerTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.defaults.feature;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.FakeClient;
 import org.kitteh.irc.client.library.element.ISupportParameter;
@@ -25,11 +25,11 @@ public class ISupportManagerTest {
     public void testParam() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter("MEOW=PURR");
-        Assert.assertEquals(manager.getClient(), param.getClient());
-        Assert.assertEquals("MEOW", param.getName());
-        Assert.assertTrue(param.getValue().isPresent());
-        Assert.assertEquals("PURR", param.getValue().get());
-        Assert.assertTrue(param.toString().contains("MEOW") && param.toString().contains("PURR"));
+        Assertions.assertEquals(manager.getClient(), param.getClient());
+        Assertions.assertEquals("MEOW", param.getName());
+        Assertions.assertTrue(param.getValue().isPresent());
+        Assertions.assertEquals("PURR", param.getValue().get());
+        Assertions.assertTrue(param.toString().contains("MEOW") && param.toString().contains("PURR"));
     }
 
     /**
@@ -39,8 +39,8 @@ public class ISupportManagerTest {
     public void casemapping() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.CaseMapping.NAME + '=' + CaseMapping.RFC1459.name());
-        Assert.assertTrue(ISupportParameter.CaseMapping.class.isAssignableFrom(param.getClass()));
-        Assert.assertEquals(CaseMapping.RFC1459, ((ISupportParameter.CaseMapping) param).getCaseMapping());
+        Assertions.assertTrue(ISupportParameter.CaseMapping.class.isAssignableFrom(param.getClass()));
+        Assertions.assertEquals(CaseMapping.RFC1459, ((ISupportParameter.CaseMapping) param).getCaseMapping());
     }
 
     /**
@@ -49,7 +49,7 @@ public class ISupportManagerTest {
     @Test
     public void casemappingFailName() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.CaseMapping.class.isAssignableFrom(manager.createParameter(ISupportParameter.CaseMapping.NAME + "=MEOW").getClass()));
+        Assertions.assertFalse(ISupportParameter.CaseMapping.class.isAssignableFrom(manager.createParameter(ISupportParameter.CaseMapping.NAME + "=MEOW").getClass()));
         this.verifyException(manager);
     }
 
@@ -59,7 +59,7 @@ public class ISupportManagerTest {
     @Test
     public void casemappingFailEmpty() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.CaseMapping.class.isAssignableFrom(manager.createParameter(ISupportParameter.CaseMapping.NAME).getClass()));
+        Assertions.assertFalse(ISupportParameter.CaseMapping.class.isAssignableFrom(manager.createParameter(ISupportParameter.CaseMapping.NAME).getClass()));
         this.verifyException(manager);
     }
 
@@ -70,8 +70,8 @@ public class ISupportManagerTest {
     public void channellen() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.ChannelLen.NAME + "=15");
-        Assert.assertTrue(ISupportParameter.ChannelLen.class.isAssignableFrom(param.getClass()));
-        Assert.assertEquals(15, ((ISupportParameter.ChannelLen) param).getInteger());
+        Assertions.assertTrue(ISupportParameter.ChannelLen.class.isAssignableFrom(param.getClass()));
+        Assertions.assertEquals(15, ((ISupportParameter.ChannelLen) param).getInteger());
     }
 
     /**
@@ -80,7 +80,7 @@ public class ISupportManagerTest {
     @Test
     public void channellenFailValue() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.ChannelLen.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChannelLen.NAME + "=MEOW").getClass()));
+        Assertions.assertFalse(ISupportParameter.ChannelLen.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChannelLen.NAME + "=MEOW").getClass()));
         this.verifyException(manager);
     }
 
@@ -91,13 +91,13 @@ public class ISupportManagerTest {
     public void channelLimit() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.ChanLimit.NAME + "=#:5,!:3");
-        Assert.assertTrue(ISupportParameter.ChanLimit.class.isAssignableFrom(param.getClass()));
+        Assertions.assertTrue(ISupportParameter.ChanLimit.class.isAssignableFrom(param.getClass()));
         ISupportParameter.ChanLimit limit = (ISupportParameter.ChanLimit) param;
-        Assert.assertEquals(2, limit.getLimits().size());
-        Assert.assertTrue(limit.getLimits().containsKey('#'));
-        Assert.assertEquals(5, limit.getLimits().get('#').intValue());
-        Assert.assertTrue(limit.getLimits().containsKey('!'));
-        Assert.assertEquals(3, limit.getLimits().get('!').intValue());
+        Assertions.assertEquals(2, limit.getLimits().size());
+        Assertions.assertTrue(limit.getLimits().containsKey('#'));
+        Assertions.assertEquals(5, limit.getLimits().get('#').intValue());
+        Assertions.assertTrue(limit.getLimits().containsKey('!'));
+        Assertions.assertEquals(3, limit.getLimits().get('!').intValue());
     }
 
     /**
@@ -106,7 +106,7 @@ public class ISupportManagerTest {
     @Test
     public void chanlimitFailValueSplit() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.ChanLimit.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChanLimit.NAME + "=MEOW").getClass()));
+        Assertions.assertFalse(ISupportParameter.ChanLimit.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChanLimit.NAME + "=MEOW").getClass()));
         this.verifyException(manager);
     }
 
@@ -116,7 +116,7 @@ public class ISupportManagerTest {
     @Test
     public void chanlimitFailValueInt() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.ChanLimit.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChanLimit.NAME + "=#:MEOW").getClass()));
+        Assertions.assertFalse(ISupportParameter.ChanLimit.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChanLimit.NAME + "=#:MEOW").getClass()));
         this.verifyException(manager);
     }
 
@@ -126,7 +126,7 @@ public class ISupportManagerTest {
     @Test
     public void channellenFailEmpty() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.ChannelLen.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChannelLen.NAME).getClass()));
+        Assertions.assertFalse(ISupportParameter.ChannelLen.class.isAssignableFrom(manager.createParameter(ISupportParameter.ChannelLen.NAME).getClass()));
         this.verifyException(manager);
     }
 
@@ -137,21 +137,21 @@ public class ISupportManagerTest {
     public void chanmodes() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.ChanModes.NAME + "=ME,O,W,CA,T");
-        Assert.assertTrue(ISupportParameter.ChanModes.class.isAssignableFrom(param.getClass()));
+        Assertions.assertTrue(ISupportParameter.ChanModes.class.isAssignableFrom(param.getClass()));
         ISupportParameter.ChanModes modes = (ISupportParameter.ChanModes) param;
-        Assert.assertEquals(6, modes.getModes().size());
-        Assert.assertEquals('M', modes.getModes().get(0).getChar());
-        Assert.assertEquals(ChannelMode.Type.A_MASK, modes.getModes().get(0).getType());
-        Assert.assertEquals('E', modes.getModes().get(1).getChar());
-        Assert.assertEquals(ChannelMode.Type.A_MASK, modes.getModes().get(1).getType());
-        Assert.assertEquals('O', modes.getModes().get(2).getChar());
-        Assert.assertEquals(ChannelMode.Type.B_PARAMETER_ALWAYS, modes.getModes().get(2).getType());
-        Assert.assertEquals('W', modes.getModes().get(3).getChar());
-        Assert.assertEquals(ChannelMode.Type.C_PARAMETER_ON_SET, modes.getModes().get(3).getType());
-        Assert.assertEquals('C', modes.getModes().get(4).getChar());
-        Assert.assertEquals(ChannelMode.Type.D_PARAMETER_NEVER, modes.getModes().get(4).getType());
-        Assert.assertEquals('A', modes.getModes().get(5).getChar());
-        Assert.assertEquals(ChannelMode.Type.D_PARAMETER_NEVER, modes.getModes().get(5).getType());
+        Assertions.assertEquals(6, modes.getModes().size());
+        Assertions.assertEquals('M', modes.getModes().get(0).getChar());
+        Assertions.assertEquals(ChannelMode.Type.A_MASK, modes.getModes().get(0).getType());
+        Assertions.assertEquals('E', modes.getModes().get(1).getChar());
+        Assertions.assertEquals(ChannelMode.Type.A_MASK, modes.getModes().get(1).getType());
+        Assertions.assertEquals('O', modes.getModes().get(2).getChar());
+        Assertions.assertEquals(ChannelMode.Type.B_PARAMETER_ALWAYS, modes.getModes().get(2).getType());
+        Assertions.assertEquals('W', modes.getModes().get(3).getChar());
+        Assertions.assertEquals(ChannelMode.Type.C_PARAMETER_ON_SET, modes.getModes().get(3).getType());
+        Assertions.assertEquals('C', modes.getModes().get(4).getChar());
+        Assertions.assertEquals(ChannelMode.Type.D_PARAMETER_NEVER, modes.getModes().get(4).getType());
+        Assertions.assertEquals('A', modes.getModes().get(5).getChar());
+        Assertions.assertEquals(ChannelMode.Type.D_PARAMETER_NEVER, modes.getModes().get(5).getType());
     }
 
     /**
@@ -161,11 +161,11 @@ public class ISupportManagerTest {
     public void chantypes() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.ChanTypes.NAME + "=#!");
-        Assert.assertTrue(ISupportParameter.ChanTypes.class.isAssignableFrom(param.getClass()));
+        Assertions.assertTrue(ISupportParameter.ChanTypes.class.isAssignableFrom(param.getClass()));
         ISupportParameter.ChanTypes types = (ISupportParameter.ChanTypes) param;
-        Assert.assertEquals(2, types.getTypes().size());
-        Assert.assertEquals('#', types.getTypes().get(0).charValue());
-        Assert.assertEquals('!', types.getTypes().get(1).charValue());
+        Assertions.assertEquals(2, types.getTypes().size());
+        Assertions.assertEquals('#', types.getTypes().get(0).charValue());
+        Assertions.assertEquals('!', types.getTypes().get(1).charValue());
     }
 
     /**
@@ -175,8 +175,8 @@ public class ISupportManagerTest {
     public void network() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.Network.NAME + "=Meow");
-        Assert.assertTrue(ISupportParameter.Network.class.isAssignableFrom(param.getClass()));
-        Assert.assertEquals("Meow", ((ISupportParameter.Network) param).getNetworkName());
+        Assertions.assertTrue(ISupportParameter.Network.class.isAssignableFrom(param.getClass()));
+        Assertions.assertEquals("Meow", ((ISupportParameter.Network) param).getNetworkName());
     }
 
     /**
@@ -186,8 +186,8 @@ public class ISupportManagerTest {
     public void nicklen() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.NickLen.NAME + "=4");
-        Assert.assertTrue(ISupportParameter.NickLen.class.isAssignableFrom(param.getClass()));
-        Assert.assertEquals(4, ((ISupportParameter.NickLen) param).getInteger());
+        Assertions.assertTrue(ISupportParameter.NickLen.class.isAssignableFrom(param.getClass()));
+        Assertions.assertEquals(4, ((ISupportParameter.NickLen) param).getInteger());
     }
 
     /**
@@ -197,13 +197,13 @@ public class ISupportManagerTest {
     public void prefix() {
         DefaultISupportManager manager = this.getManager();
         ISupportParameter param = manager.createParameter(ISupportParameter.Prefix.NAME + "=(ov)@+");
-        Assert.assertTrue(ISupportParameter.Prefix.class.isAssignableFrom(param.getClass()));
+        Assertions.assertTrue(ISupportParameter.Prefix.class.isAssignableFrom(param.getClass()));
         ISupportParameter.Prefix prefix = (ISupportParameter.Prefix) param;
-        Assert.assertEquals(2, prefix.getModes().size());
-        Assert.assertEquals('o', prefix.getModes().get(0).getChar());
-        Assert.assertEquals('@', prefix.getModes().get(0).getNickPrefix());
-        Assert.assertEquals('v', prefix.getModes().get(1).getChar());
-        Assert.assertEquals('+', prefix.getModes().get(1).getNickPrefix());
+        Assertions.assertEquals(2, prefix.getModes().size());
+        Assertions.assertEquals('o', prefix.getModes().get(0).getChar());
+        Assertions.assertEquals('@', prefix.getModes().get(0).getNickPrefix());
+        Assertions.assertEquals('v', prefix.getModes().get(1).getChar());
+        Assertions.assertEquals('+', prefix.getModes().get(1).getNickPrefix());
     }
 
     /**
@@ -212,7 +212,7 @@ public class ISupportManagerTest {
     @Test
     public void prefixFailPattern() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.Prefix.class.isAssignableFrom(manager.createParameter(ISupportParameter.Prefix.NAME + "=(ov@+").getClass()));
+        Assertions.assertFalse(ISupportParameter.Prefix.class.isAssignableFrom(manager.createParameter(ISupportParameter.Prefix.NAME + "=(ov@+").getClass()));
         this.verifyException(manager);
     }
 
@@ -222,7 +222,7 @@ public class ISupportManagerTest {
     @Test
     public void prefixFailSize() {
         DefaultISupportManager manager = this.getManager();
-        Assert.assertFalse(ISupportParameter.Prefix.class.isAssignableFrom(manager.createParameter(ISupportParameter.Prefix.NAME + "=(ov)@").getClass()));
+        Assertions.assertFalse(ISupportParameter.Prefix.class.isAssignableFrom(manager.createParameter(ISupportParameter.Prefix.NAME + "=(ov)@").getClass()));
         this.verifyException(manager);
     }
 
@@ -231,8 +231,8 @@ public class ISupportManagerTest {
      */
     @Test
     public void whox() {
-        Assert.assertTrue(ISupportParameter.WhoX.class.isAssignableFrom(this.getManager().createParameter(ISupportParameter.WhoX.NAME).getClass()));
-        Assert.assertTrue(ISupportParameter.WhoX.class.isAssignableFrom(this.getManager().createParameter(ISupportParameter.WhoX.NAME + "=MEOW").getClass()));
+        Assertions.assertTrue(ISupportParameter.WhoX.class.isAssignableFrom(this.getManager().createParameter(ISupportParameter.WhoX.NAME).getClass()));
+        Assertions.assertTrue(ISupportParameter.WhoX.class.isAssignableFrom(this.getManager().createParameter(ISupportParameter.WhoX.NAME + "=MEOW").getClass()));
     }
 
     private class KittenParameter implements ISupportParameter {
@@ -268,28 +268,28 @@ public class ISupportManagerTest {
         TriFunction<Client, String, String, ? extends ISupportParameter> naughtyKitten = (client, name, value) -> new KittenParameter(true);
 
         // Register
-        Assert.assertTrue(!manager.registerParameter("KITTEN", kitten).isPresent());
+        Assertions.assertTrue(!manager.registerParameter("KITTEN", kitten).isPresent());
         // Is it registered?
         Optional<TriFunction<Client, String, String, ? extends ISupportParameter>> optionalGotten = manager.getCreator("KITTEN");
-        Assert.assertTrue(optionalGotten.isPresent());
-        Assert.assertEquals(kitten, optionalGotten.get());
+        Assertions.assertTrue(optionalGotten.isPresent());
+        Assertions.assertEquals(kitten, optionalGotten.get());
         // Get parameter
-        Assert.assertTrue(KittenParameter.class.isAssignableFrom(manager.createParameter("KITTEN").getClass()));
+        Assertions.assertTrue(KittenParameter.class.isAssignableFrom(manager.createParameter("KITTEN").getClass()));
         // Remove
         Optional<TriFunction<Client, String, String, ? extends ISupportParameter>> optionalRemoved = manager.unregisterParameter("KITTEN");
-        Assert.assertTrue(optionalRemoved.isPresent());
-        Assert.assertEquals(kitten, optionalRemoved.get());
+        Assertions.assertTrue(optionalRemoved.isPresent());
+        Assertions.assertEquals(kitten, optionalRemoved.get());
 
         // Register it again, to test removal on replacement registration.
         manager.registerParameter("KITTEN", kitten);
         // Register the naughty version
         Optional<TriFunction<Client, String, String, ? extends ISupportParameter>> optionalReplaced = manager.registerParameter("KITTEN", naughtyKitten);
         // Was it replaced?
-        Assert.assertTrue(optionalReplaced.isPresent());
-        Assert.assertEquals(kitten, optionalReplaced.get());
+        Assertions.assertTrue(optionalReplaced.isPresent());
+        Assertions.assertEquals(kitten, optionalReplaced.get());
 
         // Fire exception
-        Assert.assertFalse(KittenParameter.class.isAssignableFrom(manager.createParameter("KITTEN").getClass()));
+        Assertions.assertFalse(KittenParameter.class.isAssignableFrom(manager.createParameter("KITTEN").getClass()));
         this.verifyException(manager);
     }
 
@@ -298,7 +298,7 @@ public class ISupportManagerTest {
      */
     @Test
     public void stringTo() {
-        Assert.assertEquals(DefaultISupportManager.class.getSimpleName() + " ()", this.getManager().toString());
+        Assertions.assertEquals(DefaultISupportManager.class.getSimpleName() + " ()", this.getManager().toString());
     }
 
     private void verifyException(@NonNull DefaultISupportManager manager) {

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/MessageTagTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/MessageTagTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.defaults.feature;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.FakeClient;
 import org.kitteh.irc.client.library.element.MessageTag;
 
@@ -18,13 +18,13 @@ public class MessageTagTest {
     @Test
     public void multiTag() {
         List<MessageTag> tags = new FakeClient().getMessageTagManager().getCapabilityTags("aaa=bbb;ccc;example.com/ddd=eee");
-        Assert.assertEquals("Failed to process multiple tags", 3, tags.size());
-        Assert.assertEquals("Failed to process valid tag name", tags.get(0).getName(), "aaa");
-        Assert.assertEquals("Failed to process valid tag value", tags.get(0).getValue().get(), "bbb");
-        Assert.assertEquals("Failed to process valid tag name", tags.get(1).getName(), "ccc");
-        Assert.assertTrue("Failed to process lack of tag value", !tags.get(1).getValue().isPresent());
-        Assert.assertEquals("Failed to process valid tag name", tags.get(2).getName(), "example.com/ddd");
-        Assert.assertEquals("Failed to process valid tag value", tags.get(2).getValue().get(), "eee");
+        Assertions.assertEquals(3, tags.size(), "Failed to process multiple tags");
+        Assertions.assertEquals(tags.get(0).getName(), "aaa", "Failed to process valid tag name");
+        Assertions.assertEquals(tags.get(0).getValue().get(), "bbb", "Failed to process valid tag value");
+        Assertions.assertEquals(tags.get(1).getName(), "ccc", "Failed to process valid tag name");
+        Assertions.assertTrue(!tags.get(1).getValue().isPresent(), "Failed to process lack of tag value");
+        Assertions.assertEquals(tags.get(2).getName(), "example.com/ddd", "Failed to process valid tag name");
+        Assertions.assertEquals(tags.get(2).getValue().get(), "eee", "Failed to process valid tag value");
     }
 
     private static final String TIME = "2012-06-30T23:59:60.419Z";
@@ -35,8 +35,8 @@ public class MessageTagTest {
     @Test
     public void timeTag() {
         List<MessageTag> tags = new FakeClient().getMessageTagManager().getCapabilityTags("time=" + TIME);
-        Assert.assertEquals("Failed to process time tag", 1, tags.size());
-        Assert.assertTrue("Failed to process time tag as MessageTag.Time", tags.get(0) instanceof MessageTag.Time);
-        Assert.assertEquals("Failed to process time tag", ((MessageTag.Time) tags.get(0)).getTime(), Instant.parse(TIME));
+        Assertions.assertEquals(1, tags.size(), "Failed to process time tag");
+        Assertions.assertTrue(tags.get(0) instanceof MessageTag.Time, "Failed to process time tag as MessageTag.Time");
+        Assertions.assertEquals(((MessageTag.Time) tags.get(0)).getTime(), Instant.parse(TIME), "Failed to process time tag");
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/ServerInfoTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/ServerInfoTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.defaults.feature;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.defaults.element.isupport.DefaultISupportChanModes;
 import org.kitteh.irc.client.library.defaults.element.mode.DefaultChannelMode;
@@ -23,19 +23,19 @@ public class ServerInfoTest {
         final DefaultServerInfo serverInfo = new DefaultServerInfo(client);
         serverInfo.addISupportParameter(new DefaultISupportChanModes(client, DefaultISupportChanModes.NAME, "b,k,l,imnDdRcC"));
         List<ChannelMode> modes = serverInfo.getChannelModes();
-        Assert.assertEquals(11, modes.size());
-        Assert.assertEquals(1, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.A_MASK).count());
-        Assert.assertEquals(1, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.B_PARAMETER_ALWAYS).count());
-        Assert.assertEquals(1, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.C_PARAMETER_ON_SET).count());
-        Assert.assertEquals(8, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.D_PARAMETER_NEVER).count());
+        Assertions.assertEquals(11, modes.size());
+        Assertions.assertEquals(1, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.A_MASK).count());
+        Assertions.assertEquals(1, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.B_PARAMETER_ALWAYS).count());
+        Assertions.assertEquals(1, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.C_PARAMETER_ON_SET).count());
+        Assertions.assertEquals(8, modes.stream().filter(mode -> mode.getType() == ChannelMode.Type.D_PARAMETER_NEVER).count());
         serverInfo.addCustomChannelMode(new DefaultChannelMode(client, 'z', ChannelMode.Type.D_PARAMETER_NEVER));
         serverInfo.addCustomChannelMode(new DefaultChannelMode(client, 'd', ChannelMode.Type.C_PARAMETER_ON_SET));
         List<ChannelMode> modesRedux = serverInfo.getChannelModes();
-        Assert.assertEquals(12, modesRedux.size());
-        Assert.assertEquals(1, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.A_MASK).count());
-        Assert.assertEquals(1, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.B_PARAMETER_ALWAYS).count());
-        Assert.assertEquals(2, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.C_PARAMETER_ON_SET).count());
-        Assert.assertEquals(8, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.D_PARAMETER_NEVER).count());
-        Assert.assertEquals(ChannelMode.Type.C_PARAMETER_ON_SET, serverInfo.getChannelMode('d').get().getType());
+        Assertions.assertEquals(12, modesRedux.size());
+        Assertions.assertEquals(1, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.A_MASK).count());
+        Assertions.assertEquals(1, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.B_PARAMETER_ALWAYS).count());
+        Assertions.assertEquals(2, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.C_PARAMETER_ON_SET).count());
+        Assertions.assertEquals(8, modesRedux.stream().filter(mode -> mode.getType() == ChannelMode.Type.D_PARAMETER_NEVER).count());
+        Assertions.assertEquals(ChannelMode.Type.C_PARAMETER_ON_SET, serverInfo.getChannelMode('d').get().getType());
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/isupport/MaxListTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/isupport/MaxListTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.defaults.feature.isupport;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.defaults.element.isupport.DefaultISupportMaxList;
 import org.kitteh.irc.client.library.element.ISupportParameter;
@@ -13,33 +13,33 @@ public class MaxListTest {
     @Test
     public void testMaxList() {
         ISupportParameter.MaxList maxList = new DefaultISupportMaxList(Mockito.mock(Client.class), "MAXLIST", "b:60,e:60,I:60");
-        Assert.assertEquals("b should be 60", 60, maxList.getLimit('b'));
-        Assert.assertEquals("q should be -1", -1, maxList.getLimit('q'));
-        Assert.assertEquals("e should be 60", 60, maxList.getLimit('e'));
-        Assert.assertEquals("I should be 60", 60, maxList.getLimit('I'));
-        Assert.assertEquals("Should be 3 limit data", 3, maxList.getAllLimitData().size());
+        Assertions.assertEquals(60, maxList.getLimit('b'), "b should be 60");
+        Assertions.assertEquals(-1, maxList.getLimit('q'), "q should be -1");
+        Assertions.assertEquals(60, maxList.getLimit('e'), "e should be 60");
+        Assertions.assertEquals(60, maxList.getLimit('I'), "I should be 60");
+        Assertions.assertEquals(3, maxList.getAllLimitData().size(), "Should be 3 limit data");
         Optional<ISupportParameter.MaxList.LimitData> bDataOpt = maxList.getLimitData('b');
-        Assert.assertTrue("b data should be present", bDataOpt.isPresent());
-        Assert.assertFalse("q data should not be present", maxList.getLimitData('q').isPresent());
+        Assertions.assertTrue(bDataOpt.isPresent(), "b data should be present");
+        Assertions.assertFalse(maxList.getLimitData('q').isPresent(), "q data should not be present");
         ISupportParameter.MaxList.LimitData bData = bDataOpt.get();
-        Assert.assertEquals("b via data should be 60", 60, bData.getLimit());
-        Assert.assertEquals("Should be one char in b data", 1, bData.getModes().size());
-        Assert.assertTrue("b should be in b data", bData.getModes().contains('b'));
+        Assertions.assertEquals(60, bData.getLimit(), "b via data should be 60");
+        Assertions.assertEquals(1, bData.getModes().size(), "Should be one char in b data");
+        Assertions.assertTrue(bData.getModes().contains('b'), "b should be in b data");
     }
 
     @Test
     public void testMaxListMerged() {
         ISupportParameter.MaxList maxList = new DefaultISupportMaxList(Mockito.mock(Client.class), "MAXLIST", "bqeI:100");
-        Assert.assertEquals("b should be 100", 100, maxList.getLimit('b'));
-        Assert.assertEquals("q should be 100", 100, maxList.getLimit('q'));
-        Assert.assertEquals("e should be 100", 100, maxList.getLimit('e'));
-        Assert.assertEquals("I should be 100", 100, maxList.getLimit('I'));
-        Assert.assertEquals("Should be 1 limit data", 1, maxList.getAllLimitData().size());
+        Assertions.assertEquals(100, maxList.getLimit('b'), "b should be 100");
+        Assertions.assertEquals(100, maxList.getLimit('q'), "q should be 100");
+        Assertions.assertEquals(100, maxList.getLimit('e'), "e should be 100");
+        Assertions.assertEquals(100, maxList.getLimit('I'), "I should be 100");
+        Assertions.assertEquals(1, maxList.getAllLimitData().size(), "Should be 1 limit data");
         Optional<ISupportParameter.MaxList.LimitData> bDataOpt = maxList.getLimitData('b');
-        Assert.assertTrue("bData should be present", bDataOpt.isPresent());
+        Assertions.assertTrue(bDataOpt.isPresent(), "bData should be present");
         ISupportParameter.MaxList.LimitData bData = bDataOpt.get();
-        Assert.assertEquals("b via data should be 60", 100, bData.getLimit());
-        Assert.assertEquals("Should be 4 chars in b data", 4, bData.getModes().size());
-        Assert.assertTrue("b should be in b data", bData.getModes().contains('b'));
+        Assertions.assertEquals(100, bData.getLimit(), "b via data should be 60");
+        Assertions.assertEquals(4, bData.getModes().size(), "Should be 4 chars in b data");
+        Assertions.assertTrue(bData.getModes().contains('b'), "b should be in b data");
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/sts/StsHandlerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/sts/StsHandlerTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.defaults.feature.sts;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.FakeClient;
 import org.kitteh.irc.client.library.defaults.element.DefaultCapabilityState;
 import org.kitteh.irc.client.library.defaults.element.DefaultServerMessage;
@@ -33,7 +33,7 @@ public class StsHandlerTest {
         final FakeClient client = new FakeClient();
         client.setSecure(false);
         final StubMachine machine = new StubMachine();
-        Assert.assertEquals(machine.getCurrentState(), StsClientState.UNKNOWN);
+        Assertions.assertEquals(machine.getCurrentState(), StsClientState.UNKNOWN);
 
         StsHandler handler = new StsHandler(machine, client);
 
@@ -43,16 +43,16 @@ public class StsHandlerTest {
         List<ServerMessage> messages = new ArrayList<>();
         messages.add(new DefaultServerMessage(":test.kitteh CAP ^o^ LS :" + policyString, new ArrayList<>()));
         handler.onCapLs(new CapabilitiesSupportedListEvent(client, messages, true, capabilities));
-        Assert.assertEquals(machine.getCurrentState(), StsClientState.STS_PRESENT_RECONNECTING);
+        Assertions.assertEquals(machine.getCurrentState(), StsClientState.STS_PRESENT_RECONNECTING);
 
         StsPolicy extractedPolicy = machine.getPolicy();
         final String port = extractedPolicy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT);
-        Assert.assertEquals("1234", port);
+        Assertions.assertEquals("1234", port);
 
         final String duration = extractedPolicy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_DURATION);
-        Assert.assertEquals("300", duration);
+        Assertions.assertEquals("300", duration);
 
-        Assert.assertTrue(extractedPolicy.getFlags().contains("foobar"));
+        Assertions.assertTrue(extractedPolicy.getFlags().contains("foobar"));
     }
 
     /**
@@ -64,7 +64,7 @@ public class StsHandlerTest {
         final FakeClient client = new FakeClient();
         client.setSecure(false);
         final StubMachine machine = new StubMachine();
-        Assert.assertEquals(machine.getCurrentState(), StsClientState.UNKNOWN);
+        Assertions.assertEquals(machine.getCurrentState(), StsClientState.UNKNOWN);
 
         StsHandler handler = new StsHandler(machine, client);
 
@@ -74,16 +74,16 @@ public class StsHandlerTest {
         List<ServerMessage> messages = new ArrayList<>();
         messages.add(new DefaultServerMessage(":test.kitteh CAP ^o^ LS :" + policyString, new ArrayList<>()));
         handler.onCapLs(new CapabilitiesSupportedListEvent(client, messages, true, capabilities));
-        Assert.assertEquals(machine.getCurrentState(), StsClientState.STS_PRESENT_RECONNECTING);
+        Assertions.assertEquals(machine.getCurrentState(), StsClientState.STS_PRESENT_RECONNECTING);
 
         StsPolicy extractedPolicy = machine.getPolicy();
         final String port = extractedPolicy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT);
-        Assert.assertEquals("7681", port);
+        Assertions.assertEquals("7681", port);
 
         final String duration = extractedPolicy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_DURATION);
-        Assert.assertEquals("300", duration);
+        Assertions.assertEquals("300", duration);
 
-        Assert.assertTrue(extractedPolicy.getFlags().contains("foobar"));
+        Assertions.assertTrue(extractedPolicy.getFlags().contains("foobar"));
     }
 
     /**
@@ -95,7 +95,7 @@ public class StsHandlerTest {
         final FakeClient client = new FakeClient();
         client.setSecure(false);
         final StubMachine machine = new StubMachine();
-        Assert.assertEquals(machine.getCurrentState(), StsClientState.UNKNOWN);
+        Assertions.assertEquals(machine.getCurrentState(), StsClientState.UNKNOWN);
 
         StsHandler handler = new StsHandler(machine, client);
 
@@ -104,22 +104,22 @@ public class StsHandlerTest {
         capabilities.add(new DefaultCapabilityState(client, policyString));
         ServerMessage message = new DefaultServerMessage(":test.kitteh CAP ^o^ NEW :" + policyString, new ArrayList<>());
         handler.onCapNew(new CapabilitiesNewSupportedEvent(client, message, true, capabilities));
-        Assert.assertEquals(machine.getCurrentState(), StsClientState.STS_PRESENT_RECONNECTING);
+        Assertions.assertEquals(machine.getCurrentState(), StsClientState.STS_PRESENT_RECONNECTING);
 
         StsPolicy extractedPolicy = machine.getPolicy();
         final String port = extractedPolicy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT);
-        Assert.assertEquals("1234", port);
+        Assertions.assertEquals("1234", port);
 
         final String duration = extractedPolicy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_DURATION);
-        Assert.assertEquals("300", duration);
+        Assertions.assertEquals("300", duration);
 
-        Assert.assertTrue(extractedPolicy.getFlags().contains("foobar"));
+        Assertions.assertTrue(extractedPolicy.getFlags().contains("foobar"));
     }
 
     /**
      * Checks an error is raised for an invalid port value.
      */
-    @Test(expected = KittehServerMessageException.class)
+    @Test
     public void testHandlerWithInvalidPort() {
         final FakeClient client = new FakeClient();
         client.setSecure(false);
@@ -130,13 +130,14 @@ public class StsHandlerTest {
         capabilities.add(new DefaultCapabilityState(client, policyString));
         List<ServerMessage> messages = new ArrayList<>();
         messages.add(new DefaultServerMessage(":test.kitteh CAP ^o^ LS :" + policyString, new ArrayList<>()));
-        handler.onCapLs(new CapabilitiesSupportedListEvent(client, messages, true, capabilities));
+        Assertions.assertThrows(KittehServerMessageException.class,
+                () -> handler.onCapLs(new CapabilitiesSupportedListEvent(client, messages, true, capabilities)));
     }
 
     /**
      * Checks an error is raised for an missing port value.
      */
-    @Test(expected = KittehServerMessageException.class)
+    @Test
     public void testHandlerWithMissingPortValue() {
         final FakeClient client = new FakeClient();
         client.setSecure(false);
@@ -147,7 +148,8 @@ public class StsHandlerTest {
         capabilities.add(new DefaultCapabilityState(client, policyString));
         List<ServerMessage> messages = new ArrayList<>();
         messages.add(new DefaultServerMessage(":test.kitteh CAP ^o^ LS :" + policyString, new ArrayList<>()));
-        handler.onCapLs(new CapabilitiesSupportedListEvent(client, messages, true, capabilities));
+        Assertions.assertThrows(KittehServerMessageException.class,
+                () -> handler.onCapLs(new CapabilitiesSupportedListEvent(client, messages, true, capabilities)));
     }
 
     private class StubMachine implements StsMachine {

--- a/src/test/java/org/kitteh/irc/client/library/defaults/feature/sts/StsPropertiesStorageManagerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/feature/sts/StsPropertiesStorageManagerTest.java
@@ -1,16 +1,14 @@
 package org.kitteh.irc.client.library.defaults.feature.sts;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.kitteh.irc.client.library.feature.sts.StsPolicy;
 import org.kitteh.irc.client.library.feature.sts.StsPropertiesStorageManager;
 import org.kitteh.irc.client.library.feature.sts.StsStorageManager;
 import org.kitteh.irc.client.library.util.StsUtil;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.Executors;
@@ -19,27 +17,27 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class StsPropertiesStorageManagerTest {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     /**
      * Checks that the simple bundled storage manager works.
      */
     @Test
-    public void testSimpleOperations() throws IOException {
-        final File tempFile = this.temporaryFolder.newFile("sts.properties");
+    public void testSimpleOperations() {
+        final File tempFile = new File(this.temporaryFolder, "sts.properties");
         final Path path = tempFile.toPath();
 
         StsPropertiesStorageManager sut = new StsPropertiesStorageManager(path);
         sut.addEntry("kitteh.org", 500, StsUtil.getStsPolicyFromString(",", StsPolicy.POLICY_OPTION_KEY_PORT + "=6697,cats"));
 
-        Assert.assertTrue(sut.hasEntry("kitteh.org"));
+        Assertions.assertTrue(sut.hasEntry("kitteh.org"));
         final Optional<StsPolicy> optionalPolicy = sut.getEntry("kitteh.org");
-        Assert.assertTrue(optionalPolicy.isPresent());
+        Assertions.assertTrue(optionalPolicy.isPresent());
         final StsPolicy policy = optionalPolicy.get();
-        Assert.assertTrue(policy.getOptions().containsKey(StsPolicy.POLICY_OPTION_KEY_PORT));
-        Assert.assertEquals("6697", policy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT));
-        Assert.assertTrue(policy.getFlags().contains("cats"));
+        Assertions.assertTrue(policy.getOptions().containsKey(StsPolicy.POLICY_OPTION_KEY_PORT));
+        Assertions.assertEquals("6697", policy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT));
+        Assertions.assertTrue(policy.getFlags().contains("cats"));
     }
 
     /**
@@ -47,21 +45,21 @@ public class StsPropertiesStorageManagerTest {
      * with reading.
      */
     @Test
-    public void testSimpleReading() throws IOException {
-        final File tempFile = this.temporaryFolder.newFile("sts.properties");
+    public void testSimpleReading() {
+        final File tempFile = new File(this.temporaryFolder, "sts.properties");
         final Path path = tempFile.toPath();
         StsPropertiesStorageManager sut1 = new StsPropertiesStorageManager(path);
         sut1.addEntry("kitteh.org", 500, StsUtil.getStsPolicyFromString(",", StsPolicy.POLICY_OPTION_KEY_PORT + "=6697,cats"));
 
-        Assert.assertTrue(sut1.hasEntry("kitteh.org"));
+        Assertions.assertTrue(sut1.hasEntry("kitteh.org"));
         StsPropertiesStorageManager sut2 = new StsPropertiesStorageManager(path);
-        Assert.assertTrue(sut2.hasEntry("kitteh.org"));
+        Assertions.assertTrue(sut2.hasEntry("kitteh.org"));
         final Optional<StsPolicy> optionalPolicy = sut2.getEntry("kitteh.org");
-        Assert.assertTrue(optionalPolicy.isPresent());
+        Assertions.assertTrue(optionalPolicy.isPresent());
         final StsPolicy policy = optionalPolicy.get();
-        Assert.assertTrue(policy.getOptions().containsKey(StsPolicy.POLICY_OPTION_KEY_PORT));
-        Assert.assertEquals("6697", policy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT));
-        Assert.assertTrue(policy.getFlags().contains("cats"));
+        Assertions.assertTrue(policy.getOptions().containsKey(StsPolicy.POLICY_OPTION_KEY_PORT));
+        Assertions.assertEquals("6697", policy.getOptions().get(StsPolicy.POLICY_OPTION_KEY_PORT));
+        Assertions.assertTrue(policy.getFlags().contains("cats"));
     }
 
     /**
@@ -69,8 +67,8 @@ public class StsPropertiesStorageManagerTest {
      * with expiration (UGLY).
      */
     @Test
-    public void testDelay() throws InterruptedException, IOException {
-        final File tempFile = this.temporaryFolder.newFile("sts.properties");
+    public void testDelay() throws InterruptedException {
+        final File tempFile = new File(this.temporaryFolder, "sts.properties");
         final Path path = tempFile.toPath();
         StsPropertiesStorageManager sut = new StsPropertiesStorageManager(path);
         sut.addEntry("kitteh.org", 0, StsUtil.getStsPolicyFromString(",", StsPolicy.POLICY_OPTION_KEY_PORT + "=6697,cats"));
@@ -78,17 +76,17 @@ public class StsPropertiesStorageManagerTest {
         final AtomicBoolean okay = new AtomicBoolean(true);
         scheduler.schedule(() -> okay.set(sut.hasEntry("kitteh.org")), 1000, TimeUnit.MILLISECONDS);
         scheduler.awaitTermination(3000, TimeUnit.MILLISECONDS);
-        Assert.assertFalse(okay.get());
+        Assertions.assertFalse(okay.get());
     }
 
     @Test
-    public void testReloading() throws IOException {
-        final File tempFile = this.temporaryFolder.newFile("sts.properties");
+    public void testReloading() {
+        final File tempFile = new File(this.temporaryFolder, "sts.properties");
         final Path path = tempFile.toPath();
         StsStorageManager sut1 = StsUtil.getDefaultStorageManager(path);
         sut1.addEntry("kitteh.org", 500, StsUtil.getStsPolicyFromString(",", StsPolicy.POLICY_OPTION_KEY_PORT + "=6697,cats"));
         StsStorageManager sut2 = StsUtil.getDefaultStorageManager(path);
-        Assert.assertTrue(sut2.hasEntry("kitteh.org"));
+        Assertions.assertTrue(sut2.hasEntry("kitteh.org"));
     }
 
 }

--- a/src/test/java/org/kitteh/irc/client/library/feature/DefaultMessageTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/feature/DefaultMessageTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.feature;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.defaults.feature.SimpleDefaultMessageMap;
 import org.kitteh.irc.client.library.feature.defaultmessage.DefaultMessageType;
 
@@ -16,7 +16,7 @@ public class DefaultMessageTest {
         SimpleDefaultMessageMap defaults = new SimpleDefaultMessageMap("foo")
                 .setDefault(DefaultMessageType.QUIT, "My kittens bring all the boys to the yard");
 
-        Assert.assertEquals("My kittens bring all the boys to the yard", defaults.getDefault(DefaultMessageType.QUIT).orElse(null));
+        Assertions.assertEquals("My kittens bring all the boys to the yard", defaults.getDefault(DefaultMessageType.QUIT).orElse(null));
     }
 
     @Test
@@ -43,9 +43,9 @@ public class DefaultMessageTest {
             }
         }
 
-        Assert.assertEquals(DefaultMessageType.values().length - 1, foos);
-        Assert.assertEquals(1, bars);
-        Assert.assertEquals(0, unknowns);
+        Assertions.assertEquals(DefaultMessageType.values().length - 1, foos);
+        Assertions.assertEquals(1, bars);
+        Assertions.assertEquals(0, unknowns);
     }
 
     @Test
@@ -54,7 +54,7 @@ public class DefaultMessageTest {
                 .setDefault(DefaultMessageType.QUIT, "stuff")
                 .setDefault(DefaultMessageType.QUIT, "otherStuff");
 
-        Assert.assertEquals("otherStuff", defaults.getDefault(DefaultMessageType.QUIT).orElse(null));
+        Assertions.assertEquals("otherStuff", defaults.getDefault(DefaultMessageType.QUIT).orElse(null));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class DefaultMessageTest {
         SimpleDefaultMessageMap defaults = new SimpleDefaultMessageMap("unset")
                 .setDefault(DefaultMessageType.QUIT, "kittens");
 
-        Assert.assertEquals("kittens", defaults.getDefault(DefaultMessageType.QUIT, "set").orElse(null));
-        Assert.assertEquals("unset", defaults.getDefault(DefaultMessageType.KICK, "unset").orElse(null));
+        Assertions.assertEquals("kittens", defaults.getDefault(DefaultMessageType.QUIT, "set").orElse(null));
+        Assertions.assertEquals("unset", defaults.getDefault(DefaultMessageType.KICK, "unset").orElse(null));
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/feature/auth/SaslEcdsaNist256PChallengeTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/feature/auth/SaslEcdsaNist256PChallengeTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.feature.auth;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -29,7 +29,7 @@ public class SaslEcdsaNist256PChallengeTest {
         ECPublicKey publicKeyO = keyPair.getPublic();
         ECPrivateKey privateKeyO = keyPair.getPrivate();
         String signature = SaslEcdsaNist256PChallenge.sign(privateKeyO, CHALLENGE);
-        Assert.assertTrue("Failed to verify signed challenge", SaslEcdsaNist256PChallenge.verify(publicKeyO, CHALLENGE, signature));
+        Assertions.assertTrue(SaslEcdsaNist256PChallenge.verify(publicKeyO, CHALLENGE, signature), "Failed to verify signed challenge");
     }
 
     /**
@@ -47,7 +47,7 @@ public class SaslEcdsaNist256PChallengeTest {
         String encodedPrivateKey = SaslEcdsaNist256PChallenge.base64Encode(keyPair.getPrivate());
         ECPrivateKey recreatedPrivateKey = SaslEcdsaNist256PChallenge.getPrivateKey(encodedPrivateKey);
         String signature = SaslEcdsaNist256PChallenge.sign(recreatedPrivateKey, CHALLENGE);
-        Assert.assertTrue("Failed to verify signed challenge", SaslEcdsaNist256PChallenge.verify(keyPair.getPublic(), CHALLENGE, signature));
+        Assertions.assertTrue(SaslEcdsaNist256PChallenge.verify(keyPair.getPublic(), CHALLENGE, signature), "Failed to verify signed challenge");
     }
 
     /**
@@ -65,6 +65,6 @@ public class SaslEcdsaNist256PChallengeTest {
         String signature = SaslEcdsaNist256PChallenge.sign(keyPair.getPrivate(), CHALLENGE);
         String encodedPublicKey = SaslEcdsaNist256PChallenge.base64Encode(keyPair.getPublic());
         ECPublicKey recreatedPublicKey = SaslEcdsaNist256PChallenge.getPublicKey(encodedPublicKey);
-        Assert.assertTrue("Failed to verify signed challenge", SaslEcdsaNist256PChallenge.verify(recreatedPublicKey, CHALLENGE, signature));
+        Assertions.assertTrue(SaslEcdsaNist256PChallenge.verify(recreatedPublicKey, CHALLENGE, signature), "Failed to verify signed challenge");
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/util/CIKeyMapTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/CIKeyMapTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.feature.CaseMapping;
 import org.mockito.Mockito;
@@ -20,39 +20,39 @@ public class CIKeyMapTest {
     public void testWithAscii() {
         Client client = this.getMockClientWithCaseMapping(CaseMapping.ASCII);
         CIKeyMap<String> sut = new CIKeyMap<>(client);
-        Assert.assertTrue(sut.isEmpty());
+        Assertions.assertTrue(sut.isEmpty());
         sut.put("KITTEN", "foobar");
 
-        Assert.assertTrue(sut.containsKey("KITTEN"));
-        Assert.assertTrue(sut.containsKey("kitten"));
-        Assert.assertEquals("foobar", sut.get("kitten"));
-        Assert.assertEquals(1, sut.size());
-        Assert.assertTrue(sut.containsValue("foobar"));
-        Assert.assertFalse(sut.isEmpty());
-        Assert.assertArrayEquals(new String[]{"KITTEN"}, sut.keySet().toArray());
-        Assert.assertArrayEquals(new String[]{"foobar"}, sut.values().toArray());
-        Assert.assertFalse(sut.toString().isEmpty());
+        Assertions.assertTrue(sut.containsKey("KITTEN"));
+        Assertions.assertTrue(sut.containsKey("kitten"));
+        Assertions.assertEquals("foobar", sut.get("kitten"));
+        Assertions.assertEquals(1, sut.size());
+        Assertions.assertTrue(sut.containsValue("foobar"));
+        Assertions.assertFalse(sut.isEmpty());
+        Assertions.assertArrayEquals(new String[]{"KITTEN"}, sut.keySet().toArray());
+        Assertions.assertArrayEquals(new String[]{"foobar"}, sut.values().toArray());
+        Assertions.assertFalse(sut.toString().isEmpty());
 
         final Exception ex = new Exception("Not a valid key!");
-        Assert.assertFalse(sut.containsKey(ex));
-        Assert.assertNull(sut.get(ex));
-        Assert.assertNull(sut.remove(ex));
-        Assert.assertNull(sut.remove("somestring"));
-        Assert.assertNull(sut.put("somestring", "somevalue"));
-        Assert.assertEquals("somevalue", sut.put("somestring", "someothervalue"));
+        Assertions.assertFalse(sut.containsKey(ex));
+        Assertions.assertNull(sut.get(ex));
+        Assertions.assertNull(sut.remove(ex));
+        Assertions.assertNull(sut.remove("somestring"));
+        Assertions.assertNull(sut.put("somestring", "somevalue"));
+        Assertions.assertEquals("somevalue", sut.put("somestring", "someothervalue"));
         sut.clear();
-        Assert.assertTrue(sut.isEmpty());
+        Assertions.assertTrue(sut.isEmpty());
 
         Map<String, String> map = new HashMap<>(2);
         map.put("one", "two");
         map.put("three", "four");
 
         sut.putAll(map);
-        Assert.assertEquals(2, sut.size());
-        Assert.assertTrue(sut.keySet().containsAll(map.keySet()));
+        Assertions.assertEquals(2, sut.size());
+        Assertions.assertTrue(sut.keySet().containsAll(map.keySet()));
 
         sut.put("key", null);
-        Assert.assertTrue(sut.containsValue(null));
+        Assertions.assertTrue(sut.containsValue(null));
     }
 
     /**
@@ -64,18 +64,18 @@ public class CIKeyMapTest {
         CIKeyMap<String> sut = new CIKeyMap<>(client);
 
         sut.put("[cat]", "kitten");
-        Assert.assertTrue(sut.containsKey("[cat]"));
-        Assert.assertTrue(sut.containsKey("{cat}"));
-        Assert.assertEquals("kitten", sut.get("{cat}"));
+        Assertions.assertTrue(sut.containsKey("[cat]"));
+        Assertions.assertTrue(sut.containsKey("{cat}"));
+        Assertions.assertEquals("kitten", sut.get("{cat}"));
 
         sut.put("[cat]^", "kitteh");
-        Assert.assertTrue(sut.containsKey("[cat]~"));
-        Assert.assertTrue(sut.containsKey("{cat}^"));
-        Assert.assertEquals("kitteh", sut.get("{cat}^"));
-        Assert.assertEquals(2, sut.size());
+        Assertions.assertTrue(sut.containsKey("[cat]~"));
+        Assertions.assertTrue(sut.containsKey("{cat}^"));
+        Assertions.assertEquals("kitteh", sut.get("{cat}^"));
+        Assertions.assertEquals(2, sut.size());
 
-        Assert.assertEquals("kitteh", sut.remove("[cat]^"));
-        Assert.assertEquals(1, sut.size());
+        Assertions.assertEquals("kitteh", sut.remove("[cat]^"));
+        Assertions.assertEquals(1, sut.size());
     }
 
     /**
@@ -87,14 +87,14 @@ public class CIKeyMapTest {
         CIKeyMap<String> sut = new CIKeyMap<>(client);
 
         sut.put("[cat]^", "kitteh");
-        Assert.assertTrue(sut.containsKey("[cat]^"));
-        Assert.assertTrue(sut.containsKey("{cat}^"));
+        Assertions.assertTrue(sut.containsKey("[cat]^"));
+        Assertions.assertTrue(sut.containsKey("{cat}^"));
 
-        Assert.assertFalse(sut.containsKey("{cat}~"));
-        Assert.assertFalse(sut.containsValue("cat"));
-        Assert.assertNull(sut.get("kitty"));
-        Assert.assertEquals("kitteh", sut.get("{cat}^"));
-        Assert.assertEquals(1, sut.size());
+        Assertions.assertFalse(sut.containsKey("{cat}~"));
+        Assertions.assertFalse(sut.containsValue("cat"));
+        Assertions.assertNull(sut.get("kitty"));
+        Assertions.assertEquals("kitteh", sut.get("{cat}^"));
+        Assertions.assertEquals(1, sut.size());
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/util/CISetTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/CISetTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.Client;
 import org.kitteh.irc.client.library.feature.CaseMapping;
 import org.mockito.Mockito;
@@ -21,45 +21,45 @@ public class CISetTest {
     public void testWithAscii() {
         Client client = this.getMockClientWithCaseMapping(CaseMapping.ASCII);
         CISet sut = new CISet(client);
-        Assert.assertTrue(sut.isEmpty());
-        Assert.assertTrue(sut.add("CAT"));
-        Assert.assertTrue(sut.contains("cat"));
-        Assert.assertTrue(sut.contains("CAT"));
-        Assert.assertTrue(sut.contains("CAt"));
-        Assert.assertFalse(sut.contains(null));
-        Assert.assertTrue(sut.remove("cat"));
-        Assert.assertFalse(sut.remove("cat"));
-        Assert.assertFalse(sut.remove(null));
-        Assert.assertFalse(sut.iterator().hasNext());
+        Assertions.assertTrue(sut.isEmpty());
+        Assertions.assertTrue(sut.add("CAT"));
+        Assertions.assertTrue(sut.contains("cat"));
+        Assertions.assertTrue(sut.contains("CAT"));
+        Assertions.assertTrue(sut.contains("CAt"));
+        Assertions.assertFalse(sut.contains(null));
+        Assertions.assertTrue(sut.remove("cat"));
+        Assertions.assertFalse(sut.remove("cat"));
+        Assertions.assertFalse(sut.remove(null));
+        Assertions.assertFalse(sut.iterator().hasNext());
 
         sut.add("dog");
-        Assert.assertEquals("dog", sut.iterator().next());
-        Assert.assertEquals(1, sut.size());
+        Assertions.assertEquals("dog", sut.iterator().next());
+        Assertions.assertEquals(1, sut.size());
         sut.clear();
-        Assert.assertEquals(0, sut.size());
+        Assertions.assertEquals(0, sut.size());
 
         List<String> list = Arrays.asList("cat", "magpie", "rhino");
         sut.addAll(list);
 
-        Assert.assertEquals(3, sut.size());
+        Assertions.assertEquals(3, sut.size());
         for (Object item : sut.toArray()) {
-            Assert.assertTrue(list.contains(item));
+            Assertions.assertTrue(list.contains(item));
         }
 
         String[] foobar = new String[3];
         sut.toArray(foobar);
 
-        Assert.assertFalse(foobar[0].isEmpty());
-        Assert.assertTrue(sut.containsAll(list));
+        Assertions.assertFalse(foobar[0].isEmpty());
+        Assertions.assertTrue(sut.containsAll(list));
         List<String> listlist = Arrays.asList("cat", "magpie", "rhino", "kangaroo");
-        Assert.assertFalse(sut.containsAll(listlist));
-        Assert.assertFalse(sut.toString().isEmpty());
+        Assertions.assertFalse(sut.containsAll(listlist));
+        Assertions.assertFalse(sut.toString().isEmpty());
 
         sut.retainAll(Collections.singletonList("cat"));
-        Assert.assertEquals(1, sut.size());
+        Assertions.assertEquals(1, sut.size());
 
         sut.removeAll(listlist);
-        Assert.assertTrue(sut.isEmpty());
+        Assertions.assertTrue(sut.isEmpty());
     }
 
     /**
@@ -70,7 +70,7 @@ public class CISetTest {
         Client client = this.getMockClientWithCaseMapping(CaseMapping.RFC1459);
         CISet sut = new CISet(client);
         sut.add("[cat]^");
-        Assert.assertTrue(sut.contains("{cat}~"));
+        Assertions.assertTrue(sut.contains("{cat}~"));
     }
 
     /**
@@ -81,7 +81,7 @@ public class CISetTest {
         Client client = this.getMockClientWithCaseMapping(CaseMapping.STRICT_RFC1459);
         CISet sut = new CISet(client);
         sut.add("[cat]");
-        Assert.assertTrue(sut.contains("{cat}"));
+        Assertions.assertTrue(sut.contains("{cat}"));
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/util/CtcpUtilTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/CtcpUtilTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -22,7 +22,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void fromCTCP() {
-        Assert.assertEquals(UNCONVERTED_1, CtcpUtil.fromCtcp(CONVERTED_1));
+        Assertions.assertEquals(UNCONVERTED_1, CtcpUtil.fromCtcp(CONVERTED_1));
     }
 
     /**
@@ -30,7 +30,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void thereAndBackAgain() {
-        Assert.assertEquals(UNCONVERTED_1, CtcpUtil.fromCtcp(CtcpUtil.toCtcp(UNCONVERTED_1))); // For fun
+        Assertions.assertEquals(UNCONVERTED_1, CtcpUtil.fromCtcp(CtcpUtil.toCtcp(UNCONVERTED_1))); // For fun
     }
 
     /**
@@ -38,7 +38,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void snip() {
-        Assert.assertEquals(UNCONVERTED_1, CtcpUtil.fromCtcp(SNIP_1));
+        Assertions.assertEquals(UNCONVERTED_1, CtcpUtil.fromCtcp(SNIP_1));
     }
 
     /**
@@ -46,7 +46,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void toCTCP() {
-        Assert.assertEquals(CONVERTED_1, CtcpUtil.toCtcp(UNCONVERTED_1));
+        Assertions.assertEquals(CONVERTED_1, CtcpUtil.toCtcp(UNCONVERTED_1));
     }
 
     /**
@@ -54,7 +54,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void isCTCPTrue() {
-        Assert.assertTrue(CtcpUtil.isCtcp(CONVERTED_1));
+        Assertions.assertTrue(CtcpUtil.isCtcp(CONVERTED_1));
     }
 
     /**
@@ -62,7 +62,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void isCTCPFalse() {
-        Assert.assertFalse(CtcpUtil.isCtcp(UNCONVERTED_1));
+        Assertions.assertFalse(CtcpUtil.isCtcp(UNCONVERTED_1));
     }
 
     /**
@@ -70,7 +70,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void noEscapeToCTCP() {
-        Assert.assertEquals(CONVERTED_2, CtcpUtil.toCtcp(UNCONVERTED_2));
+        Assertions.assertEquals(CONVERTED_2, CtcpUtil.toCtcp(UNCONVERTED_2));
     }
 
     /**
@@ -78,7 +78,7 @@ public class CtcpUtilTest {
      */
     @Test
     public void noEscapeFromCTCP() {
-        Assert.assertEquals(UNCONVERTED_2, CtcpUtil.fromCtcp(CONVERTED_2));
+        Assertions.assertEquals(UNCONVERTED_2, CtcpUtil.fromCtcp(CONVERTED_2));
     }
 
     /**

--- a/src/test/java/org/kitteh/irc/client/library/util/CutterTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/CutterTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -15,16 +15,16 @@ public class CutterTest {
     @Test
     public void cut() {
         List<String> output = new Cutter.DefaultWordCutter().split("0 purrrrr 1 1 1 Meow meow mreow hisssssssss", 5);
-        Assert.assertEquals(9, output.size());
-        Assert.assertEquals("0 pur", output.get(0));
-        Assert.assertEquals("rrrr", output.get(1));
-        Assert.assertEquals("1 1 1", output.get(2));
-        Assert.assertEquals("Meow", output.get(3));
-        Assert.assertEquals("meow", output.get(4));
-        Assert.assertEquals("mreow", output.get(5));
-        Assert.assertEquals("hisss", output.get(6));
-        Assert.assertEquals("sssss", output.get(7));
-        Assert.assertEquals("s", output.get(8));
+        Assertions.assertEquals(9, output.size());
+        Assertions.assertEquals("0 pur", output.get(0));
+        Assertions.assertEquals("rrrr", output.get(1));
+        Assertions.assertEquals("1 1 1", output.get(2));
+        Assertions.assertEquals("Meow", output.get(3));
+        Assertions.assertEquals("meow", output.get(4));
+        Assertions.assertEquals("mreow", output.get(5));
+        Assertions.assertEquals("hisss", output.get(6));
+        Assertions.assertEquals("sssss", output.get(7));
+        Assertions.assertEquals("s", output.get(8));
     }
 
     /**
@@ -33,9 +33,9 @@ public class CutterTest {
     @Test
     public void cutLong() {
         List<String> output = new Cutter.DefaultWordCutter().split("meoooow", 5);
-        Assert.assertEquals(2, output.size());
-        Assert.assertEquals("meooo", output.get(0));
-        Assert.assertEquals("ow", output.get(1));
+        Assertions.assertEquals(2, output.size());
+        Assertions.assertEquals("meooo", output.get(0));
+        Assertions.assertEquals("ow", output.get(1));
     }
 
     /**
@@ -44,24 +44,24 @@ public class CutterTest {
     @Test
     public void cutShort() {
         List<String> output = new Cutter.DefaultWordCutter().split("Hello world!", 15);
-        Assert.assertEquals(1, output.size());
-        Assert.assertEquals("Hello world!", output.get(0));
+        Assertions.assertEquals(1, output.size());
+        Assertions.assertEquals("Hello world!", output.get(0));
     }
 
     /**
      * Tests ability to fail.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cutFailNegative() {
-        new Cutter.DefaultWordCutter().split("Hi", -2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Cutter.DefaultWordCutter().split("Hi", -2));
     }
 
     /**
      * Tests ability to fail.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cutFailNull() {
-        new Cutter.DefaultWordCutter().split(null, 2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Cutter.DefaultWordCutter().split(null, 2));
     }
 
     /**
@@ -70,6 +70,6 @@ public class CutterTest {
     @Test
     public void cutSpace() {
         List<String> output = new Cutter.DefaultWordCutter().split("                     ", 3);
-        Assert.assertEquals(0, output.size());
+        Assertions.assertEquals(0, output.size());
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/util/PairTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/PairTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * It's a pair test.
@@ -13,9 +13,9 @@ public class PairTest {
     @Test
     public void testPair() {
         Pair<String, Integer> sut = new Pair<>("Cats", 4);
-        Assert.assertEquals("Cats", sut.getLeft());
-        Assert.assertEquals(4, sut.getRight().intValue());
-        Assert.assertTrue(sut.toString().contains("Cats"));
+        Assertions.assertEquals("Cats", sut.getLeft());
+        Assertions.assertEquals(4, sut.getRight().intValue());
+        Assertions.assertTrue(sut.toString().contains("Cats"));
     }
 
     /**
@@ -24,8 +24,8 @@ public class PairTest {
     @Test
     public void testPairMore() {
         Pair<String, Integer> sut = Pair.of("Cats", 4);
-        Assert.assertEquals("Cats", sut.getLeft());
-        Assert.assertEquals(4, sut.getRight().intValue());
-        Assert.assertTrue(sut.toString().contains("Cats"));
+        Assertions.assertEquals("Cats", sut.getLeft());
+        Assertions.assertEquals(4, sut.getRight().intValue());
+        Assertions.assertTrue(sut.toString().contains("Cats"));
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/util/RiskyBusinessTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/RiskyBusinessTest.java
@@ -1,7 +1,8 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -15,17 +16,19 @@ public class RiskyBusinessTest {
      */
     @Test
     public void calculatedRisk() {
-        Assert.assertEquals("purr", RiskyBusiness.assertSafe(input -> "purr", "meow"));
+        Assertions.assertEquals("purr", RiskyBusiness.assertSafe(input -> "purr", "meow"));
     }
 
     /**
      * Falls over.
      */
-    @Test(expected = AssertionError.class)
+    @Test
     public void calculatedFailure() {
-        RiskyBusiness.assertSafe(input -> {
-            throw new Exception();
-        }, "meow");
+        Assertions.assertThrows(AssertionError.class, () ->
+            RiskyBusiness.assertSafe(input -> {
+                throw new Exception();
+            }, "meow")
+        );
     }
 
     /**
@@ -36,7 +39,7 @@ public class RiskyBusinessTest {
     @Test
     public void testConstructorIsPrivate() throws Exception {
         Constructor<RiskyBusiness> constructor = RiskyBusiness.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assertions.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }

--- a/src/test/java/org/kitteh/irc/client/library/util/SanityTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/SanityTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -21,9 +21,9 @@ public class SanityTest {
     /**
      * Tests nullCheck with invalid info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nullCheckFail() {
-        Sanity.nullCheck((Object) null, "Failure!");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.nullCheck((Object) null, "Failure!"));
     }
 
     /**
@@ -37,17 +37,17 @@ public class SanityTest {
     /**
      * Tests nullCheck with invalid array info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nullCheckArrayFail() {
-        Sanity.nullCheck((Object[]) null, "Failure!");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.nullCheck((Object[]) null, "Failure!"));
     }
 
     /**
      * Tests nullCheck with invalid array info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nullCheckArrayFailElement() {
-        Sanity.nullCheck(new Object[]{"meow", null}, "Failure!");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.nullCheck(new Object[]{"meow", null}, "Failure!"));
     }
 
     /**
@@ -61,9 +61,9 @@ public class SanityTest {
     /**
      * Tests truthiness with invalid info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void truthFail() {
-        Sanity.truthiness(false, "Fail");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.truthiness(false, "Fail"));
     }
 
     /**
@@ -77,33 +77,33 @@ public class SanityTest {
     /**
      * Tests safeMessageCheck with invalid info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void safeMessageFailNull() {
-        Sanity.safeMessageCheck(null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.safeMessageCheck(null));
     }
 
     /**
      * Tests safeMessageCheck with invalid info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void safeMessageFailLF() {
-        Sanity.safeMessageCheck("Me\now");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.safeMessageCheck("Me\now"));
     }
 
     /**
      * Tests safeMessageCheck with invalid info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void safeMessageFailCR() {
-        Sanity.safeMessageCheck("Me\row");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.safeMessageCheck("Me\row"));
     }
 
     /**
      * Tests safeMessageCheck with invalid info.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void safeMessageFailNul() {
-        Sanity.safeMessageCheck("Me\0ow");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.safeMessageCheck("Me\0ow"));
     }
 
     @Test
@@ -111,9 +111,9 @@ public class SanityTest {
         Sanity.noSpaces("Cat", "");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void noSpacesFail() {
-        Sanity.noSpaces("Cat ", "");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Sanity.noSpaces("Cat ", ""));
     }
 
     /**
@@ -124,7 +124,7 @@ public class SanityTest {
     @Test
     public void testConstructorIsPrivate() throws Exception {
         Constructor<Sanity> constructor = Sanity.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assertions.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }

--- a/src/test/java/org/kitteh/irc/client/library/util/SslUtilTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/SslUtilTest.java
@@ -1,8 +1,8 @@
 package org.kitteh.irc.client.library.util;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.TrustManagerFactory;
 
@@ -15,7 +15,7 @@ public class SslUtilTest {
      */
     @Test
     public void testSecure1() {
-        Assert.assertTrue(SslUtil.isInsecure(InsecureTrustManagerFactory.INSTANCE));
+        Assertions.assertTrue(SslUtil.isInsecure(InsecureTrustManagerFactory.INSTANCE));
     }
 
     /**
@@ -25,6 +25,6 @@ public class SslUtilTest {
      */
     @Test
     public void testSecure3() throws Exception {
-        Assert.assertFalse(SslUtil.isInsecure(TrustManagerFactory.getInstance("PKIX")));
+        Assertions.assertFalse(SslUtil.isInsecure(TrustManagerFactory.getInstance("PKIX")));
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/util/StringUtilTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/StringUtilTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -15,8 +15,8 @@ public class StringUtilTest {
      */
     @Test
     public void combineSplitWithSpaces() {
-        Assert.assertEquals("item one two", StringUtil.combineSplit(new String[]{"item", "one", "two"}, 0));
-        Assert.assertEquals("one two", StringUtil.combineSplit(new String[]{"item", "one", "two"}, 1));
+        Assertions.assertEquals("item one two", StringUtil.combineSplit(new String[]{"item", "one", "two"}, 0));
+        Assertions.assertEquals("one two", StringUtil.combineSplit(new String[]{"item", "one", "two"}, 1));
     }
 
     /**
@@ -24,23 +24,23 @@ public class StringUtilTest {
      */
     @Test
     public void combineSplitCustomDelimiter() {
-        Assert.assertEquals("one  two", StringUtil.combineSplit(new String[]{"item", "one", "two", "three"}, 1, 2, "  "));
+        Assertions.assertEquals("one  two", StringUtil.combineSplit(new String[]{"item", "one", "two", "three"}, 1, 2, "  "));
     }
 
     /**
      * Tests an empty array.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void combineSplitEmpty() {
-        StringUtil.combineSplit(new String[]{}, 0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtil.combineSplit(new String[]{}, 0));
     }
 
     /**
      * Tests negative index.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void combineSplitNegative() {
-        StringUtil.combineSplit(new String[]{"one"}, -1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtil.combineSplit(new String[]{"one"}, -1));
     }
 
     /**
@@ -54,25 +54,25 @@ public class StringUtilTest {
     /**
      * And what happens if one fails?
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rainbowNullMessage() {
-        StringUtil.makeRainbow(null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtil.makeRainbow(null));
     }
 
     /**
      * Rainbows are Strings, but just for good input.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rainbowNullOrder() {
-        StringUtil.makeRainbow("La da de dee da dee da doo", null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtil.makeRainbow("La da de dee da dee da doo", null));
     }
 
     /**
      * And users are hard to predict.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rainbowNotAColor() {
-        StringUtil.makeRainbow("Someday we'll find it, the rainbow test coverage, the coders, the users, and me.", new Format[]{Format.UNDERLINE});
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtil.makeRainbow("Someday we'll find it, the rainbow test coverage, the coders, the users, and me.", new Format[]{Format.UNDERLINE}));
     }
 
     /**
@@ -83,7 +83,7 @@ public class StringUtilTest {
     @Test
     public void testConstructorIsPrivate() throws Exception {
         Constructor<StringUtil> constructor = StringUtil.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assertions.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }

--- a/src/test/java/org/kitteh/irc/client/library/util/StsUtilTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/StsUtilTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kitteh.irc.client.library.feature.sts.StsPolicy;
 
 /**
@@ -15,19 +15,19 @@ public class StsUtilTest {
     public void testParseSeparatedKeyValueString() {
         String myStr = "foo,bar=cat,kitten=dog";
         StsPolicy retVal = StsUtil.getStsPolicyFromString(",", myStr);
-        Assert.assertTrue(retVal.getFlags().contains("foo"));
-        Assert.assertTrue(retVal.getOptions().containsKey("bar"));
-        Assert.assertTrue(retVal.getOptions().containsKey("kitten"));
-        Assert.assertFalse(retVal.getOptions().containsKey("foo"));
+        Assertions.assertTrue(retVal.getFlags().contains("foo"));
+        Assertions.assertTrue(retVal.getOptions().containsKey("bar"));
+        Assertions.assertTrue(retVal.getOptions().containsKey("kitten"));
+        Assertions.assertFalse(retVal.getOptions().containsKey("foo"));
 
-        Assert.assertEquals(retVal.getOptions().get("kitten"), "dog");
+        Assertions.assertEquals(retVal.getOptions().get("kitten"), "dog");
     }
 
     /**
      * Tests parseSeparatedKeyValueString with invalid (null) input.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseSeparatedKeyValueStringWithNull() {
-        StsUtil.getStsPolicyFromString(",", null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StsUtil.getStsPolicyFromString(",", null));
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/util/ToStringerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/util/ToStringerTest.java
@@ -1,7 +1,7 @@
 package org.kitteh.irc.client.library.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests ToStringer.
@@ -12,7 +12,7 @@ public class ToStringerTest {
      */
     @Test
     public void toStringer() {
-        Assert.assertNotNull(new ToStringer(this)
+        Assertions.assertNotNull(new ToStringer(this)
                 .add("boolean", true)
                 .add("byte", (byte) 0x00)
                 .add("char", 'c')
@@ -30,16 +30,16 @@ public class ToStringerTest {
     /**
      * Tests a null addition parameter.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void toStringerNullAddition() {
-        new ToStringer(this).add(null, "test");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ToStringer(this).add(null, "test"));
     }
 
     /**
      * Tests a null constructor parameter.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void toStringerNullConstructor() {
-        new ToStringer(null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ToStringer(null));
     }
 }


### PR DESCRIPTION
The project currently uses the outdated JUnit 4.13.2.
In order to make it easier to write tests and easier for future contributors to easily start working with the project, this patch migrates the test suite to the modern JUnit Jupiter.

This patch contains the following changes:

- Dependencies:
  - The `junit:junit:4.13.2` dependency was replaced with `org.junit.jupiter:junit-jupiter:5.8.1`
  - Unlike JUnit 4, JUnit Jupiter does not bundle the hamcrest library, so the explicit dependency `org.hamcrest:hamcrest:2.2` was added

- Annotations
  - `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`
  - `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test` without arguments. See "Assertions" below for handling of `org.junit.Test` with an "expected" argument

- Assertions
  - `org.junit.jupiter.api.Assertions` was used as a drop-in replacement for `org.junit.Assert` in the cases the "message" argument was not used. In the cases a "message" argument was used it was moved to be the last argument instead of the first argument
  - `org.hamcrest.MatcherAssert#assertThat` was used as a drop-in replacement for `org.junit.Assert#assertThat`
  - `org.junit.jupiter.api.Assertions#assertThrows` was used to assert cases where a method call should throw an exception instead of passing an "expected" argument to the `@Test` annotation. As a side bonus, this also makes the tests stricter, as it asserts the actual method call threw the expected exception and not the code used to set up its arguments/environment.

- Misc
  - Tests using `org.junit.rules.TemporaryFolder` were rewritten to use the similar `org.junit.jupiter.api.io.TempDir`. While these two classes conceptually have the same functionality their APIs are different, and this is not a drop-in replacement.