### PR TITLE
Removed 3 unnecessary stubbings in DefaultEventListenerTest.java

### DIFF
--- a/src/test/java/org/kitteh/irc/client/library/defaults/FourthDefaultEventListenerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/FourthDefaultEventListenerTest.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 /**
  * Tests the EventListener.
  */
-public class DefaultEventListenerTest {
+public class FourthDefaultEventListenerTest {
     private Client.WithManagement client;
     private ActorTracker actorTracker;
     private DefaultEventManager eventManager;
@@ -53,8 +53,9 @@ public class DefaultEventListenerTest {
         this.exceptionListener = Mockito.mock(Listener.class);
         this.serverInfo = Mockito.mock(DefaultServerInfo.class);
         Mockito.when(this.client.getServerInfo()).thenReturn(this.serverInfo);
-        Mockito.when(this.client.getExceptionListener()).thenReturn(this.exceptionListener);
+        Mockito.when(this.client.getEventManager()).thenReturn(this.eventManager);
         Mockito.when(this.serverInfo.getCaseMapping()).thenReturn(CaseMapping.ASCII);
+        Mockito.when(this.client.getISupportManager()).thenReturn(new DefaultISupportManager(this.client));
     }
 
     // BEGIN TODO - not have this be stolen from IRCClient
@@ -132,20 +133,26 @@ public class DefaultEventListenerTest {
             return true;
         };
     }
-
-    /**
-     * Tests an unsuccessful welcome message.
-     */
+    
     @Test
-    public void test1WelcomeFail() {
-        this.fireLine(":irc.network 001");
-        Mockito.verify(this.client, Mockito.times(0)).setCurrentNick(Mockito.anyString());
-        Mockito.verify(this.exceptionListener, Mockito.times(1)).queue(Mockito.argThat(this.exception(KittehServerMessageException.class, "Nickname missing from welcome message; can't confirm")));
+    public void test5ISUPPORT() {
+        this.fireLine(":irc.network 005 Kitteh SAFELIST ELIST=CTU CHANTYPES=# EXCEPTS INVEX");
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("SAFELIST")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("ELIST")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("CHANTYPES")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("EXCEPTS")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("INVEX")));
+        Mockito.verify(this.serverInfo, Mockito.times(5)).addISupportParameter(Mockito.any());
     }
 
     @Test
-    public void testWALLOPSFail() {
-        this.fireLine(":irc.network WALLOPS");
-        Mockito.verify(this.exceptionListener, Mockito.times(1)).queue(Mockito.argThat(this.exception(KittehServerMessageException.class, "WALLOPS message too short")));
+    public void test5ISUPPORTLonger() {
+        this.fireLine(":irc.network 005 Kitteh SAFELIST ELIST=CTU CHANTYPES=# EXCEPTS INVEX :are supported by this server");
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("SAFELIST")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("ELIST")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("CHANTYPES")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("EXCEPTS")));
+        Mockito.verify(this.serverInfo, Mockito.times(1)).addISupportParameter(Mockito.argThat(this.iSupportParameter("INVEX")));
+        Mockito.verify(this.serverInfo, Mockito.times(5)).addISupportParameter(Mockito.any());
     }
 }

--- a/src/test/java/org/kitteh/irc/client/library/defaults/ThirdDefaultEventListenerTest.java
+++ b/src/test/java/org/kitteh/irc/client/library/defaults/ThirdDefaultEventListenerTest.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 /**
  * Tests the EventListener.
  */
-public class DefaultEventListenerTest {
+public class ThirdDefaultEventListenerTest {
     private Client.WithManagement client;
     private ActorTracker actorTracker;
     private DefaultEventManager eventManager;
@@ -53,7 +53,6 @@ public class DefaultEventListenerTest {
         this.exceptionListener = Mockito.mock(Listener.class);
         this.serverInfo = Mockito.mock(DefaultServerInfo.class);
         Mockito.when(this.client.getServerInfo()).thenReturn(this.serverInfo);
-        Mockito.when(this.client.getExceptionListener()).thenReturn(this.exceptionListener);
         Mockito.when(this.serverInfo.getCaseMapping()).thenReturn(CaseMapping.ASCII);
     }
 
@@ -134,18 +133,13 @@ public class DefaultEventListenerTest {
     }
 
     /**
-     * Tests an unsuccessful welcome message.
+     * Tests a successful welcome message.
      */
     @Test
-    public void test1WelcomeFail() {
-        this.fireLine(":irc.network 001");
-        Mockito.verify(this.client, Mockito.times(0)).setCurrentNick(Mockito.anyString());
-        Mockito.verify(this.exceptionListener, Mockito.times(1)).queue(Mockito.argThat(this.exception(KittehServerMessageException.class, "Nickname missing from welcome message; can't confirm")));
+    public void test1Welcome() {
+        this.fireLine(":irc.network 001 Kitteh :Welcome to the CatNet Internet Relay Chat Network Kitteh");
+        Mockito.verify(this.client, Mockito.times(1)).setCurrentNick("Kitteh");
     }
 
-    @Test
-    public void testWALLOPSFail() {
-        this.fireLine(":irc.network WALLOPS");
-        Mockito.verify(this.exceptionListener, Mockito.times(1)).queue(Mockito.argThat(this.exception(KittehServerMessageException.class, "WALLOPS message too short")));
-    }
+
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 stubbing which stubbed `getEventManager` method is created in `DefaultEventListenerTest.before` but never executed in 3 tests: `DefaultEventListenerTest.test1WelcomeFail`, `DefaultEventListenerTest.testWALLOPSFail`, `DefaultEventListenerTest.test1Welcome`.

2) 1 stubbing which stubbed `getISupportManager` method is created in `DefaultEventListenerTest.before` but never executed in 7 tests: `DefaultEventListenerTest.test1WelcomeFail`, `DefaultEventListenerTest.testWALLOPSFail`, `DefaultEventListenerTest.test4VersionNoAddressOrVersion`, `DefaultEventListenerTest.testMOTD`, `DefaultEventListenerTest.test1Welcome`,`DefaultEventListenerTest.test4Version`, `DefaultEventListenerTest.testWALLOPS`.

3) 1 stubbing which stubbed `getExceptionListener` method is created in `DefaultEventListenerTest.before` but never executed in 5 tests: `DefaultEventListenerTest.test1Welcome`, `DefaultEventListenerTest.test5ISUPPORT`, `DefaultEventListenerTest.test5ISUPPORTLonger`, `DefaultEventListenerTest.test4Version`, `DefaultEventListenerTest.testWALLOPS`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.